### PR TITLE
[SeiDB] Pt. 2 Benchmark Add RocksDB

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -1,10 +1,3 @@
-GOTOOLS := github.com/golangci/golangci-lint/cmd/golangci-lint
-VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
-COMMIT := $(shell git log -1 --format='%H')
-BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DOCKER_BUF := docker run -v $(shell pwd):/workspace --workdir /workspace bufbuild/buf
-DOCKER := $(shell which docker)
-HTTPS_GIT := https://github.com/cosmos/iavl.git
 UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
@@ -24,8 +17,8 @@ endif
 
 install:
 ifeq ($(COLORS_ON),)
-	CGO_CFLAGS="-I$(ROCKSDB_PATH)/include" CGO_LDFLAGS="-L$(ROCKSDB_PATH)/lib -L$(SNAPPY_PATH)/lib -L$(LZ4_PATH)/lib -L$(ZSTD_PATH)/lib -lrocksdb -lstdc++ -lm -lz -lsnappy -llz4 -lzstd" go install ./cmd/dumpkv
+	CGO_CFLAGS="-I$(ROCKSDB_PATH)/include" CGO_LDFLAGS="-L$(ROCKSDB_PATH)/lib -L$(SNAPPY_PATH)/lib -L$(LZ4_PATH)/lib -L$(ZSTD_PATH)/lib -lrocksdb -lstdc++ -lm -lz -lsnappy -llz4 -lzstd" go install ./cmd/seidb
 else
-	CGO_CFLAGS="-I$(ROCKSDB_PATH)/include" CGO_LDFLAGS="-L$(ROCKSDB_PATH)/lib -L$(SNAPPY_PATH)/lib -L$(LZ4_PATH)/lib -L$(ZSTD_PATH)/lib -lrocksdb -lstdc++ -lm -lz -lsnappy -llz4 -lzstd" go install $(CMDFLAGS) ./cmd/dumpkv
+	CGO_CFLAGS="-I$(ROCKSDB_PATH)/include" CGO_LDFLAGS="-L$(ROCKSDB_PATH)/lib -L$(SNAPPY_PATH)/lib -L$(LZ4_PATH)/lib -L$(ZSTD_PATH)/lib -lrocksdb -lstdc++ -lm -lz -lsnappy -llz4 -lzstd" go install $(CMDFLAGS) ./cmd/seidb
 endif
 .PHONY: install

--- a/benchmark/cmd/seidb/benchmark_iteration.go
+++ b/benchmark/cmd/seidb/benchmark_iteration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/sei-protocol/sei-db/benchmark/dbbackend/rocksdb"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +54,15 @@ func benchmarkForwardIteration(cmd *cobra.Command, args []string) {
 	BenchmarkDBIteration(rawKVInputDir, numVersions, outputDir, dbBackend, concurrency, maxOps, iterationSteps)
 }
 
-// Benchmark read latencies and throughput of db backend
+// Benchmark forward iteration performance of db backend
 func BenchmarkDBIteration(inputKVDir string, numVersions int, outputDir string, dbBackend string, concurrency int, maxOps int64, iterationSteps int) {
-	panic("Not Implemented")
+	// Iterate over db at directory
+	fmt.Printf("Iterating Over DB at  %s\n", outputDir)
+
+	if dbBackend == RocksDBBackend {
+		backend := rocksdb.RocksDBBackend{}
+		backend.BenchmarkDBForwardIteration(inputKVDir, numVersions, outputDir, concurrency, maxOps, iterationSteps)
+	}
+
+	return
 }

--- a/benchmark/cmd/seidb/benchmark_read.go
+++ b/benchmark/cmd/seidb/benchmark_read.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
 
+	"github.com/sei-protocol/sei-db/benchmark/dbbackend/rocksdb"
 	"github.com/spf13/cobra"
 )
 
@@ -53,5 +56,18 @@ func benchmarkRead(cmd *cobra.Command, args []string) {
 
 // Benchmark read latencies and throughput of db backend
 func BenchmarkRead(inputKVDir string, numVersions int, outputDir string, dbBackend string, concurrency int, maxOps int64) {
-	panic("Not Implemented")
+	// Create output directory
+	err := os.MkdirAll(outputDir, fs.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	// Iterate over files in directory
+	fmt.Printf("Reading Raw Keys and Values from %s\n", inputKVDir)
+
+	if dbBackend == RocksDBBackend {
+		backend := rocksdb.RocksDBBackend{}
+		backend.BenchmarkDBRead(inputKVDir, numVersions, outputDir, concurrency, maxOps)
+	}
+
+	return
 }

--- a/benchmark/cmd/seidb/benchmark_reverse_iteration.go
+++ b/benchmark/cmd/seidb/benchmark_reverse_iteration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/sei-protocol/sei-db/benchmark/dbbackend/rocksdb"
 	"github.com/spf13/cobra"
 )
 
@@ -55,5 +56,13 @@ func benchmarkReverseIteration(cmd *cobra.Command, args []string) {
 
 // Benchmark reverse iteration performance of db backend
 func BenchmarkDBReverseIteration(inputKVDir string, numVersions int, outputDir string, dbBackend string, concurrency int, maxOps int64, iterationSteps int) {
-	panic("Not Implemented")
+	// Reverse Iterate over db at directory
+	fmt.Printf("Iterating Over DB at  %s\n", outputDir)
+
+	if dbBackend == RocksDBBackend {
+		backend := rocksdb.RocksDBBackend{}
+		backend.BenchmarkDBReverseIteration(inputKVDir, numVersions, outputDir, concurrency, maxOps, iterationSteps)
+	}
+
+	return
 }

--- a/benchmark/cmd/seidb/benchmark_write.go
+++ b/benchmark/cmd/seidb/benchmark_write.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
 
+	"github.com/sei-protocol/sei-db/benchmark/dbbackend/rocksdb"
 	"github.com/spf13/cobra"
 )
 
@@ -53,5 +56,18 @@ func benchmarkWrite(cmd *cobra.Command, args []string) {
 
 // Benchmark write latencies and throughput of db backend
 func BenchmarkWrite(inputKVDir string, numVersions int, outputDir string, dbBackend string, concurrency int, batchSize int) {
-	panic("Not Implemented")
+	// Create output directory
+	err := os.MkdirAll(outputDir, fs.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	// Iterate over files in directory
+	fmt.Printf("Reading Raw Keys and Values from %s\n", inputKVDir)
+
+	if dbBackend == RocksDBBackend {
+		backend := rocksdb.RocksDBBackend{}
+		backend.BenchmarkDBWrite(inputKVDir, numVersions, outputDir, concurrency, batchSize)
+	}
+
+	return
 }

--- a/benchmark/cmd/seidb/main.go
+++ b/benchmark/cmd/seidb/main.go
@@ -7,10 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
+const RocksDBBackend = "rocksDB"
 
-	// TODO: Will include rocksdb, pebbledb and sqlite in future PR's
-	ValidDBBackends = map[string]bool{}
+var (
+	ValidDBBackends = map[string]bool{
+		RocksDBBackend: true,
+	}
 )
 
 func main() {

--- a/benchmark/dbbackend/rocksdb/benchmark.go
+++ b/benchmark/dbbackend/rocksdb/benchmark.go
@@ -1,0 +1,409 @@
+package rocksdb
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sei-protocol/sei-db/benchmark/utils"
+)
+
+// writeToRocksDBConcurrently generates random write load against the rocksDB
+// Given kv pairs (randomly shuffled), the version, batch size, it will spin up `concurrency` goroutines
+// each of which is assigned to a portion of the kv data and writes to db in `batchSize` batches.
+// It maintains a `latencies` channel which aggregates all the latencies
+func writeToRocksDBConcurrently(db *Database, allKVs []utils.KeyValuePair, concurrency int, version uint64, batchSize int) []time.Duration {
+	var allLatencies []time.Duration
+	latencies := make(chan time.Duration, len(allKVs))
+
+	kvsPerRoutine := len(allKVs) / concurrency
+	remainder := len(allKVs) % concurrency
+
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			start := i * kvsPerRoutine
+			end := start + kvsPerRoutine
+
+			if i == concurrency-1 {
+				end += remainder
+			}
+
+			for j := start; j < end; j += batchSize {
+				batch := NewBatch(db, version)
+
+				batchEnd := j + batchSize
+				if batchEnd > end {
+					batchEnd = end
+				}
+
+				// Add key-value pairs to the batch up to batchSize
+				for k := j; k < batchEnd; k++ {
+					kv := allKVs[k]
+					batch.Set(kv.Key, kv.Value)
+				}
+
+				startTime := time.Now()
+				err := batch.Write()
+				latency := time.Since(startTime)
+
+				if err == nil {
+					latencies <- latency
+				} else {
+					panic(err)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(latencies)
+
+	for l := range latencies {
+		allLatencies = append(allLatencies, l)
+	}
+
+	return allLatencies
+}
+
+// BenchmarkDBWrite measures random write performance of rocksdb
+// Given an input dir containing all the raw kv data, it writes to rocksdb one version after another
+func (rocksDB RocksDBBackend) BenchmarkDBWrite(inputKVDir string, numVersions int, outputDBPath string, concurrency int, batchSize int) {
+	db, err := New(outputDBPath)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	startLoad := time.Now()
+	kvData, err := utils.LoadAndShuffleKV(inputKVDir)
+	if err != nil {
+		panic(err)
+	}
+	endLoad := time.Now()
+	fmt.Printf("Finishing loading %+v kv pairs into memory %+v\n", len(kvData), endLoad.Sub(startLoad).String())
+
+	// Write each version sequentially
+	totalTime := time.Duration(0)
+	writeCount := 0
+	v := uint64(0)
+	for ; v < uint64(numVersions); v++ {
+		// Write shuffled entries to RocksDB concurrently
+		fmt.Printf("On Version %+v\n", v)
+		totalLatencies := []time.Duration{}
+		startTime := time.Now()
+		latencies := writeToRocksDBConcurrently(db, kvData, concurrency, v, batchSize)
+		endTime := time.Now()
+		totalTime = totalTime + endTime.Sub(startTime)
+		totalLatencies = append(totalLatencies, latencies...)
+		writeCount += len(latencies)
+
+		sort.Slice(totalLatencies, func(i, j int) bool { return totalLatencies[i] < totalLatencies[j] })
+		fmt.Printf("P50 Latency: %v\n", utils.CalculatePercentile(totalLatencies, 50))
+		fmt.Printf("P75 Latency: %v\n", utils.CalculatePercentile(totalLatencies, 75))
+		fmt.Printf("P99 Latency: %v\n", utils.CalculatePercentile(totalLatencies, 99))
+		fmt.Printf("Total time: %v\n", totalTime)
+		fmt.Printf("Total Successfully Written %d\n", writeCount)
+		totalLatencies = nil
+		runtime.GC()
+	}
+
+	// Log throughput
+	fmt.Printf("Total Successfully Written %d\n", writeCount)
+	fmt.Printf("Total Time taken: %v\n", totalTime)
+	fmt.Printf("Throughput: %f writes/sec\n", float64(writeCount)/totalTime.Seconds())
+	fmt.Printf("Total records written %d\n", writeCount)
+}
+
+// readFromRocksDBConcurrently generates random read load against the rocksDB
+// Given kv pairs (randomly shuffled), numVersions, it will spin up `concurrency` goroutines
+// that randomly select a version, key and query the db.
+// It only performs `maxOps“ random reads and maintains a `latencies` channel which aggregates all the latencies.
+func readFromRocksDBConcurrently(db *Database, allKVs []utils.KeyValuePair, numVersions int, concurrency int, maxOps int64) []time.Duration {
+	var allLatencies []time.Duration
+	latencies := make(chan time.Duration, maxOps)
+
+	var opCounter int64
+	wg := &sync.WaitGroup{}
+
+	// Each goroutine will handle reading a subset of kv pairs
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for {
+				currentOps := atomic.AddInt64(&opCounter, 1)
+				if currentOps > maxOps {
+					break
+				}
+				// Randomly pick a version and retrieve its column family handle
+				version := uint64(rand.Intn(numVersions))
+
+				// Randomly pick a key-value pair to read
+				kv := allKVs[rand.Intn(len(allKVs))]
+
+				startTime := time.Now()
+				_, err := db.Get(version, kv.Key)
+				latency := time.Since(startTime)
+				if err == nil {
+					latencies <- latency
+				} else {
+					panic(err)
+				}
+
+			}
+		}()
+	}
+	wg.Wait()
+	close(latencies)
+
+	for l := range latencies {
+		allLatencies = append(allLatencies, l)
+	}
+
+	return allLatencies
+}
+
+// BenchmarkDBRead measures random read performance of rocksdb
+// Given an input dir containing all the raw kv data, it generates random read load and measures performance.
+func (rocksDB RocksDBBackend) BenchmarkDBRead(inputKVDir string, numVersions int, outputDBPath string, concurrency int, maxOps int64) {
+	kvData, err := utils.LoadAndShuffleKV(inputKVDir)
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize db
+	db, err := New(outputDBPath)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	startTime := time.Now()
+	latencies := readFromRocksDBConcurrently(db, kvData, numVersions, concurrency, maxOps)
+	endTime := time.Now()
+
+	totalTime := endTime.Sub(startTime)
+
+	// Log throughput
+	fmt.Printf("Total Successfully Read %d\n", len(latencies))
+	fmt.Printf("Total Time taken: %v\n", totalTime)
+	fmt.Printf("Throughput: %f reads/sec\n", float64(len(latencies))/totalTime.Seconds())
+	fmt.Printf("Total records read %d\n", len(latencies))
+
+	// Sort latencies for percentile calculations
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+	// Calculate average latency
+	var totalLatency time.Duration
+	for _, l := range latencies {
+		totalLatency += l
+	}
+	avgLatency := totalLatency / time.Duration(len(latencies))
+
+	fmt.Printf("Average Latency: %v\n", avgLatency)
+	fmt.Printf("P50 Latency: %v\n", utils.CalculatePercentile(latencies, 50))
+	fmt.Printf("P75 Latency: %v\n", utils.CalculatePercentile(latencies, 75))
+	fmt.Printf("P99 Latency: %v\n", utils.CalculatePercentile(latencies, 99))
+}
+
+// forwardIterateRocksDBConcurrently generates forward iteration load against the rocksDB
+// Given kv pairs (randomly shuffled), numVersions, it will spin up `concurrency` goroutines
+// that randomly select a version, key, seeks to that key and starts a forward iteration for at most `numIterationSteps` steps.
+// It only performs `maxOps“ forward iterations and maintains a `latencies` channel which aggregates all the latencies.
+func forwardIterateRocksDBConcurrently(db *Database, allKVs []utils.KeyValuePair, numVersions int, concurrency int, numIterationSteps int, maxOps int64) ([]time.Duration, int) {
+	var allLatencies []time.Duration
+	var totalSteps int
+	latencies := make(chan time.Duration, maxOps)
+	steps := make(chan int, maxOps)
+
+	var opCounter int64
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for {
+				currentOps := atomic.AddInt64(&opCounter, 1)
+				if currentOps > maxOps {
+					break
+				}
+				// Randomly pick a version and retrieve its column family handle
+				version := uint64(rand.Intn(numVersions))
+
+				// Randomly pick a key-value pair to seek to
+				kv := allKVs[rand.Intn(len(allKVs))]
+
+				it := db.storage.NewIteratorCF(db.newTSReadOptions(version), db.cfHandle)
+				defer it.Close()
+
+				startTime := time.Now()
+				it.Seek(kv.Key)
+				step := 0
+				for j := 0; j < numIterationSteps && it.Valid(); it.Next() {
+					step++
+				}
+				latency := time.Since(startTime)
+
+				latencies <- latency
+				steps <- step
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(latencies)
+	close(steps)
+
+	for l := range latencies {
+		allLatencies = append(allLatencies, l)
+	}
+
+	for s := range steps {
+		totalSteps += s
+	}
+
+	return allLatencies, totalSteps
+}
+
+// BenchmarkDBForwardIteration measures forward iteration performance of rocksdb
+// Given an input dir containing all the raw kv data, it selects a random key, forward iterates and measures performance.
+func (rocksDB RocksDBBackend) BenchmarkDBForwardIteration(inputKVDir string, numVersions int, outputDBPath string, concurrency int, maxOps int64, iterationSteps int) {
+	kvData, err := utils.LoadAndShuffleKV(inputKVDir)
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize db
+	db, err := New(outputDBPath)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	startTime := time.Now()
+	latencies, totalCountIteration := forwardIterateRocksDBConcurrently(db, kvData, numVersions, concurrency, iterationSteps, maxOps)
+	endTime := time.Now()
+
+	totalTime := endTime.Sub(startTime)
+
+	// Log throughput
+	fmt.Printf("Total Prefixes Iterated: %d\n", totalCountIteration)
+	fmt.Printf("Total Time taken: %v\n", totalTime)
+	fmt.Printf("Throughput: %f iterations/sec\n", float64(totalCountIteration)/totalTime.Seconds())
+
+	// Calculate average latency
+	var totalLatency time.Duration
+	for _, l := range latencies {
+		totalLatency += l
+	}
+	avgLatency := time.Duration(int64(totalLatency) / int64(totalCountIteration))
+	fmt.Printf("Average Per-Key Latency: %v\n", avgLatency)
+}
+
+// reverseIterateRocksDBConcurrently generates reverse iteration load against the rocksDB
+// Given kv pairs (randomly shuffled), numVersions, it will spin up `concurrency` goroutines
+// that randomly select a version, key, seeks to that key and starts a reverse iteration for at most `numIterationSteps` steps.
+// It only performs `maxOps“ reverse iterations and maintains a `latencies` channel which aggregates all the latencies.
+func reverseIterateRocksDBConcurrently(db *Database, allKVs []utils.KeyValuePair, numVersions int, concurrency int, numIterationSteps int, maxOps int64) ([]time.Duration, int) {
+	var allLatencies []time.Duration
+	var totalSteps int
+	latencies := make(chan time.Duration, maxOps)
+	steps := make(chan int, maxOps)
+
+	var opCounter int64
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for {
+				currentOps := atomic.AddInt64(&opCounter, 1)
+				if currentOps > maxOps {
+					break
+				}
+				// Randomly pick a version and retrieve its column family handle
+				version := uint64(rand.Intn(numVersions))
+
+				// Randomly pick a key-value pair to seek to
+				kv := allKVs[rand.Intn(len(allKVs))]
+
+				it := db.storage.NewIteratorCF(db.newTSReadOptions(version), db.cfHandle)
+				defer it.Close()
+
+				startTime := time.Now()
+				it.Seek(kv.Key)
+				step := 0
+				for j := 0; j < numIterationSteps && it.Valid(); it.Prev() {
+					step++
+				}
+				latency := time.Since(startTime)
+
+				latencies <- latency
+				steps <- step
+
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(latencies)
+	close(steps)
+
+	for l := range latencies {
+		allLatencies = append(allLatencies, l)
+	}
+
+	for s := range steps {
+		totalSteps += s
+	}
+
+	return allLatencies, totalSteps
+}
+
+// BenchmarkDBReverseIteration measures reverse iteration performance of rocksdb
+// Given an input dir containing all the raw kv data, it selects a random key, reverse iterates and measures performance.
+func (rocksDB RocksDBBackend) BenchmarkDBReverseIteration(inputKVDir string, numVersions int, outputDBPath string, concurrency int, maxOps int64, iterationSteps int) {
+	kvData, err := utils.LoadAndShuffleKV(inputKVDir)
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize db
+	db, err := New(outputDBPath)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	startTime := time.Now()
+	latencies, totalCountIteration := reverseIterateRocksDBConcurrently(db, kvData, numVersions, concurrency, iterationSteps, maxOps)
+	endTime := time.Now()
+
+	totalTime := endTime.Sub(startTime)
+
+	// Log throughput
+	fmt.Printf("Total Prefixes Reverse-Iterated: %d\n", totalCountIteration)
+	fmt.Printf("Total Time taken: %v\n", totalTime)
+	fmt.Printf("Throughput: %f iterations/sec\n", float64(totalCountIteration)/totalTime.Seconds())
+
+	// Calculate average latency
+	var totalLatency time.Duration
+	for _, l := range latencies {
+		totalLatency += l
+	}
+	avgLatency := time.Duration(int64(totalLatency) / int64(totalCountIteration))
+	fmt.Printf("Average Per-Key Latency: %v\n", avgLatency)
+}

--- a/benchmark/dbbackend/rocksdb/db.go
+++ b/benchmark/dbbackend/rocksdb/db.go
@@ -1,0 +1,222 @@
+package rocksdb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"runtime"
+
+	"github.com/linxGnu/grocksdb"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	CFNameStateStorage = "state_storage"
+	CFNameDefault      = "default"
+	TimestampSize      = 8
+	latestVersionKey   = "s/latest"
+)
+
+var (
+	defaultWriteOpts = grocksdb.NewDefaultWriteOptions()
+	defaultReadOpts  = grocksdb.NewDefaultReadOptions()
+)
+
+type RocksDBBackend struct{}
+
+type Database struct {
+	storage  *grocksdb.DB
+	cfHandle *grocksdb.ColumnFamilyHandle
+}
+
+type Batch struct {
+	version  uint64
+	ts       [TimestampSize]byte
+	storage  *grocksdb.DB
+	cfHandle *grocksdb.ColumnFamilyHandle
+	batch    *grocksdb.WriteBatch
+}
+
+// Rocks DB Configurations
+func NewRocksDBOpts() *grocksdb.Options {
+	opts := grocksdb.NewDefaultOptions()
+	opts.SetComparator(CreateTSComparator())
+	opts.IncreaseParallelism(runtime.NumCPU())
+	opts.OptimizeLevelStyleCompaction(512 * 1024 * 1024)
+	opts.SetTargetFileSizeMultiplier(2)
+	opts.SetLevelCompactionDynamicLevelBytes(true)
+	opts.EnableStatistics()
+
+	// block based table options
+	bbto := grocksdb.NewDefaultBlockBasedTableOptions()
+
+	// 1G block cache
+	bbto.SetBlockSize(32 * 1024)
+	bbto.SetBlockCache(grocksdb.NewLRUCache(1 << 30))
+
+	bbto.SetFilterPolicy(grocksdb.NewRibbonHybridFilterPolicy(9.9, 1))
+	bbto.SetIndexType(grocksdb.KBinarySearchWithFirstKey)
+	bbto.SetOptimizeFiltersForMemory(true)
+	opts.SetBlockBasedTableFactory(bbto)
+	// improve sst file creation speed: compaction or sst file writer.
+	opts.SetCompressionOptionsParallelThreads(4)
+
+	return opts
+}
+
+// Opens RocksDB or creates new db at output path
+func OpenRocksDB(outputDBPath string) (*grocksdb.DB, *grocksdb.ColumnFamilyHandle, error) {
+	opts := grocksdb.NewDefaultOptions()
+	opts.SetCreateIfMissing(true)
+	opts.SetCreateIfMissingColumnFamilies(true)
+
+	db, cfHandles, err := grocksdb.OpenDbColumnFamilies(
+		opts,
+		outputDBPath,
+		[]string{
+			CFNameDefault,
+			CFNameStateStorage,
+		},
+		[]*grocksdb.Options{
+			opts,
+			NewRocksDBOpts(),
+		},
+	)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return db, cfHandles[1], nil
+}
+
+func New(outputDBPath string) (*Database, error) {
+	storage, cfHandle, err := OpenRocksDB(outputDBPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Database{
+		storage:  storage,
+		cfHandle: cfHandle,
+	}, nil
+}
+
+func (db *Database) Close() error {
+	db.storage.Close()
+
+	db.storage = nil
+	db.cfHandle = nil
+
+	return nil
+}
+
+// Creates new Batch without store keys prepended for writes
+func NewBatch(db *Database, version uint64) Batch {
+	var ts [TimestampSize]byte
+	binary.LittleEndian.PutUint64(ts[:], uint64(version))
+
+	batch := grocksdb.NewWriteBatch()
+	batch.Put([]byte(latestVersionKey), ts[:])
+
+	return Batch{
+		version:  version,
+		ts:       ts,
+		storage:  db.storage,
+		cfHandle: db.cfHandle,
+		batch:    batch,
+	}
+}
+
+func (b Batch) Set(key, value []byte) error {
+	b.batch.PutCFWithTS(b.cfHandle, key, b.ts[:], value)
+	return nil
+}
+
+func (b Batch) Write() error {
+	defer b.batch.Destroy()
+	return b.storage.Write(defaultWriteOpts, b.batch)
+}
+
+func (db *Database) Get(version uint64, key []byte) ([]byte, error) {
+	slice, err := db.getSlice(version, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RocksDB slice: %w", err)
+	}
+
+	return copyAndFreeSlice(slice), nil
+}
+
+func (db *Database) getSlice(version uint64, key []byte) (*grocksdb.Slice, error) {
+	return db.storage.GetCF(
+		db.newTSReadOptions(version),
+		db.cfHandle,
+		key,
+	)
+}
+
+func copyAndFreeSlice(s *grocksdb.Slice) []byte {
+	defer s.Free()
+	if !s.Exists() {
+		return nil
+	}
+
+	return slices.Clone(s.Data())
+}
+
+func (db *Database) newTSReadOptions(version uint64) *grocksdb.ReadOptions {
+	var ts [TimestampSize]byte
+	binary.LittleEndian.PutUint64(ts[:], version)
+
+	readOpts := grocksdb.NewDefaultReadOptions()
+	readOpts.SetTimestamp(ts[:])
+
+	return readOpts
+}
+
+// Timestamp comparator for different versions
+func CreateTSComparator() *grocksdb.Comparator {
+	return grocksdb.NewComparatorWithTimestamp(
+		"leveldb.BytewiseComparator.u64ts",
+		TimestampSize,
+		compare,
+		compareTS,
+		compareWithoutTS,
+	)
+}
+
+func compareTS(bz1 []byte, bz2 []byte) int {
+	ts1 := binary.LittleEndian.Uint64(bz1)
+	ts2 := binary.LittleEndian.Uint64(bz2)
+
+	switch {
+	case ts1 < ts2:
+		return -1
+
+	case ts1 > ts2:
+		return 1
+
+	default:
+		return 0
+	}
+}
+
+func compare(a []byte, b []byte) int {
+	ret := compareWithoutTS(a, true, b, true)
+	if ret != 0 {
+		return ret
+	}
+
+	return -compareTS(a[len(a)-TimestampSize:], b[len(b)-TimestampSize:])
+}
+
+func compareWithoutTS(a []byte, aHasTS bool, b []byte, bHasTS bool) int {
+	if aHasTS {
+		a = a[:len(a)-TimestampSize]
+	}
+	if bHasTS {
+		b = b[:len(b)-TimestampSize]
+	}
+
+	return bytes.Compare(a, b)
+}

--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -4,8 +4,10 @@ go 1.19
 
 require (
 	github.com/cosmos/iavl v0.21.0-alpha.1.0.20230904092046-df3db2d96583
+	github.com/linxGnu/grocksdb v1.8.4
 	github.com/spf13/cobra v1.7.0
 	github.com/tendermint/tm-db v0.6.8-0.20220519162814-e24b96538a12
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 )
 
 require (
@@ -33,7 +35,6 @@ require (
 	github.com/petermattis/goid v0.0.0-20230317030725-371a4b8eda08 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/tendermint v0.37.0-dev // indirect
 	go.etcd.io/bbolt v1.3.7 // indirect

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -111,6 +111,8 @@ github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQs
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/linxGnu/grocksdb v1.8.4 h1:ZMsBpPpJNtRLHiKKp0mI7gW+NT4s7UgfD5xHxx1jVRo=
+github.com/linxGnu/grocksdb v1.8.4/go.mod h1:xZCIb5Muw+nhbDK4Y5UJuOrin5MceOuiXkVUR7vp4WY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -168,7 +170,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -187,6 +188,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/benchmark/utils/utils.go
+++ b/benchmark/utils/utils.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -199,4 +201,54 @@ func PickRandomKVFile(inputKVDir string, processedFiles *sync.Map) string {
 	selected := availableFiles[rand.Intn(len(availableFiles))]
 	processedFiles.Store(selected, true)
 	return selected
+}
+
+func ListAllFiles(dir string) ([]string, error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return []string{}, err
+	}
+	// Extract file nams from input KV dir
+	var fileNames []string
+	for _, file := range files {
+		fileNames = append(fileNames, file.Name())
+	}
+
+	return fileNames, nil
+}
+
+func LoadAndShuffleKV(inputDir string) ([]KeyValuePair, error) {
+	var allKVs []KeyValuePair
+	mu := &sync.Mutex{}
+	wg := &sync.WaitGroup{}
+
+	allFiles, err := ListAllFiles(inputDir)
+	if err != nil {
+		log.Fatalf("Failed to list all files: %v", err)
+	}
+
+	for _, file := range allFiles {
+		wg.Add(1)
+		go func(id string, selectedFile string) {
+			defer wg.Done()
+
+			kvEntries, err := ReadKVEntriesFromFile(filepath.Join(id, selectedFile))
+			if err != nil {
+				panic(err)
+			}
+
+			// Safely append the kvEntries to allKVs
+			mu.Lock()
+			allKVs = append(allKVs, kvEntries...)
+			fmt.Printf("Done processing file %+v\n", filepath.Join(id, selectedFile))
+			mu.Unlock()
+		}(inputDir, file)
+	}
+	wg.Wait()
+
+	rand.Shuffle(len(allKVs), func(i, j int) {
+		allKVs[i], allKVs[j] = allKVs[j], allKVs[i]
+	})
+
+	return allKVs, nil
 }


### PR DESCRIPTION
## Describe your changes and provide context
- Adds Benchmarking code for RocksDB
- Adds RocksDB backend for write, read, forward/reverse iteration
- Adds benchmarking code to compute latencies, throughput etc for each
- NOTE: RocksDB backend for benchmark is separate from SS layer. We don't prepend a store key to each write, iteration does not have an end

## Testing performed to validate your change
- Tested rocksdb benchmark on local and on node
