### PR TITLE
[Bug] Fix concurrent map read 

### DIFF
--- a/sc/memiavl/db/tree.go
+++ b/sc/memiavl/db/tree.go
@@ -73,7 +73,7 @@ func New(cacheSize int) *Tree {
 	return NewEmptyTree(0, 0, cacheSize)
 }
 
-// New creates a empty tree with initial-version,
+// NewWithInitialVersion creates an empty tree with initial-version,
 // it happens when a new store created at the middle of the chain.
 func NewWithInitialVersion(initialVersion uint32, cacheSize int) *Tree {
 	return NewEmptyTree(0, initialVersion, cacheSize)
@@ -137,25 +137,17 @@ func (t *Tree) ApplyChangeSet(changeSet iavl.ChangeSet) {
 }
 
 func (t *Tree) set(key, value []byte) {
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
 	if value == nil {
 		// the value could be nil when replaying changes from write-ahead-log because of protobuf decoding
 		value = []byte{}
 	}
 	t.root, _ = setRecursive(t.root, key, value, t.version+1, t.cowVersion)
-	if t.cache != nil {
-		t.cache.Add(&cacheNode{key, value})
-	}
+	t.addToCache(key, value)
 }
 
 func (t *Tree) remove(key []byte) {
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
 	_, t.root, _ = removeRecursive(t.root, key, t.version+1, t.cowVersion)
-	if t.cache != nil {
-		t.cache.Remove(key)
-	}
+	t.removeFromCache(key)
 }
 
 // SaveVersion increases the version number and optionally updates the hashes
@@ -216,22 +208,17 @@ func (t *Tree) GetByIndex(index int64) ([]byte, []byte) {
 }
 
 func (t *Tree) Get(key []byte) []byte {
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
-	if t.cache != nil {
-		if node := t.cache.Get(key); node != nil {
-			return node.(*cacheNode).value
-		}
+	value := t.getFromCache(key)
+	if value != nil {
+		return value
 	}
 
-	_, value := t.GetWithIndex(key)
+	_, value = t.GetWithIndex(key)
 	if value == nil {
 		return nil
 	}
 
-	if t.cache != nil {
-		t.cache.Add(&cacheNode{key, value})
-	}
+	t.addToCache(key, value)
 	return value
 }
 
@@ -309,4 +296,31 @@ func nextVersionU32(v uint32, initialVersion uint32) uint32 {
 		return initialVersion
 	}
 	return v + 1
+}
+
+func (t *Tree) addToCache(key, value []byte) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	if t.cache != nil {
+		t.cache.Add(&cacheNode{key, value})
+	}
+}
+
+func (t *Tree) removeFromCache(key []byte) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	if t.cache != nil {
+		t.cache.Remove(key)
+	}
+}
+
+func (t *Tree) getFromCache(key []byte) []byte {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	if t.cache != nil {
+		if node := t.cache.Get(key); node != nil {
+			return node.(*cacheNode).value
+		}
+	}
+	return nil
 }

--- a/sc/memiavl/db/tree.go
+++ b/sc/memiavl/db/tree.go
@@ -216,8 +216,8 @@ func (t *Tree) GetByIndex(index int64) ([]byte, []byte) {
 }
 
 func (t *Tree) Get(key []byte) []byte {
-	t.mtx.RLock()
-	defer t.mtx.RUnlock()
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	if t.cache != nil {
 		if node := t.cache.Get(key); node != nil {
 			return node.(*cacheNode).value

--- a/sc/memiavl/store/rootmulti/store.go
+++ b/sc/memiavl/store/rootmulti/store.go
@@ -208,7 +208,7 @@ func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 // Implements interface MultiStore
 // used to createQueryContext, abci_query or grpc query service.
 func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
-	if version == 0 || (rs.lastCommitInfo != nil && version == rs.lastCommitInfo.Version) {
+	if version == 0 || (rs.lastCommitInfo != nil && version == rs.LatestVersion()) {
 		return rs.CacheMultiStore(), nil
 	}
 	rs.mtx.RLock()
@@ -216,6 +216,7 @@ func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStor
 	opts := rs.opts
 	opts.TargetVersion = uint32(version)
 	opts.ReadOnly = true
+	rs.logger.Info("Loading memiavl store from version", "version", version)
 	db, err := memiavl.Load(rs.dir, opts)
 	if err != nil {
 		return nil, err

--- a/ss/setup.go
+++ b/ss/setup.go
@@ -126,7 +126,7 @@ func recoverStateStore(logger logger.Logger, stateStore types.StateStore, homePa
 	}
 	firstVersion := firstEntry.Version
 	delta := uint64(firstVersion) - firstOffset
-	targetStartOffset := uint64(ssLatestVersion) + delta
+	targetStartOffset := uint64(ssLatestVersion) - delta
 	logger.Info(fmt.Sprintf("Start replaying changelog for SS from offset %d to %d", targetStartOffset, lastOffset))
 	if targetStartOffset < lastOffset {
 		return streamHandler.Replay(targetStartOffset, lastOffset, func(index uint64, entry proto.ChangelogEntry) error {

--- a/ss/setup.go
+++ b/ss/setup.go
@@ -62,7 +62,7 @@ func SetupStateStore(
 	if err != nil {
 		return nil, err
 	}
-	logger.Info(fmt.Sprintf("Finished replaying changelog for SS"))
+	logger.Info("Finished replaying changelog for SS")
 
 	// Setup QueryMultiStore
 	qms := store.NewMultiStore(cms, ss, exposeStoreKeys)

--- a/ss/setup.go
+++ b/ss/setup.go
@@ -62,6 +62,7 @@ func SetupStateStore(
 	if err != nil {
 		return nil, err
 	}
+	logger.Info(fmt.Sprintf("Finished replaying changelog for SS"))
 
 	// Setup QueryMultiStore
 	qms := store.NewMultiStore(cms, ss, exposeStoreKeys)
@@ -126,7 +127,7 @@ func recoverStateStore(logger logger.Logger, stateStore types.StateStore, homePa
 	firstVersion := firstEntry.Version
 	delta := uint64(firstVersion) - firstOffset
 	targetStartOffset := uint64(ssLatestVersion) + delta
-	logger.Info(fmt.Sprintf("Start replaying changelog for SS from offset %d", targetStartOffset))
+	logger.Info(fmt.Sprintf("Start replaying changelog for SS from offset %d to %d", targetStartOffset, lastOffset))
 	if targetStartOffset < lastOffset {
 		return streamHandler.Replay(targetStartOffset, lastOffset, func(index uint64, entry proto.ChangelogEntry) error {
 			return commitToStateStore(stateStore, entry.Version, entry.Changesets)


### PR DESCRIPTION
## Describe your changes and provide context
We need to add a write lock for the tree cache access to avoid panics for concurrent map read.
<img width="1261" alt="image" src="https://github.com/sei-protocol/sei-db/assets/50607998/ba2ac7b9-f75a-4c18-af6e-8fc510c37c81">
## Testing performed to validate your change
Tested in atlantic-2 testnet

