### PR TITLE
[SeiDB] Parallelize Import

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,10 @@ type StateStoreConfig struct {
 	// PruneIntervalSeconds defines the interval in seconds to trigger pruning
 	// default to 60 seconds
 	PruneIntervalSeconds int `mapstructure:"prune-interval-seconds"`
+
+	// ImportNumWorkers defines the number of goroutines used during import
+	// defaults to 1
+	ImportNumWorkers int `mapstructure:"import-num-workers"`
 }
 
 func DefaultStateCommitConfig() StateCommitConfig {

--- a/config/config.go
+++ b/config/config.go
@@ -77,5 +77,6 @@ func DefaultStateStoreConfig() StateStoreConfig {
 		AsyncWriteBuffer:     100,
 		KeepRecent:           0,
 		PruneIntervalSeconds: 60,
+		ImportNumWorkers:     1,
 	}
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -55,4 +55,8 @@ keep-recent = {{ .StateStore.KeepRecent }}
 # default to 60 seconds
 prune-interval-seconds = {{ .StateStore.PruneIntervalSeconds }}
 
+# ImportNumWorkers defines the number of goroutines used during import
+# defaults to 1
+import-num-workers = {{ .StateStore.PruneIntervalSeconds }}
+
 `

--- a/config/toml.go
+++ b/config/toml.go
@@ -57,6 +57,6 @@ prune-interval-seconds = {{ .StateStore.PruneIntervalSeconds }}
 
 # ImportNumWorkers defines the number of goroutines used during import
 # defaults to 1
-import-num-workers = {{ .StateStore.PruneIntervalSeconds }}
+import-num-workers = {{ .StateStore.ImportNumWorkers }}
 
 `

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -26,7 +26,6 @@ const (
 
 	// TODO: Make configurable
 	ImportCommitBatchSize = 10000
-	ImportMaxretries      = 5
 )
 
 var (

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -6,9 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
@@ -245,10 +243,6 @@ func (db *Database) ReverseIterator(storeKey string, version int64, start, end [
 	}
 
 	return newPebbleDBIterator(itr, storePrefix(storeKey), start, end, version, true), nil
-}
-
-func jitter() time.Duration {
-	return time.Duration(rand.Intn(1000)) * time.Millisecond
 }
 
 // Import loads the initial version of the state in parallel with numWorkers goroutines

--- a/ss/rocksdb/db.go
+++ b/ss/rocksdb/db.go
@@ -223,36 +223,6 @@ func (db *Database) ReverseIterator(storeKey string, version int64, start, end [
 	return NewRocksDBIterator(itr, prefix, start, end, true), nil
 }
 
-// // Import loads the initial version of the state
-// // TODO: Parallelize Import
-// func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry) error {
-// 	batch := NewBatch(db, version)
-
-// 	var counter int
-// 	for entry := range ch {
-// 		err := batch.Set(entry.StoreKey, entry.Key, entry.Value)
-// 		if err != nil {
-// 			return err
-// 		}
-
-// 		counter++
-// 		if counter%ImportCommitBatchSize == 0 {
-// 			if err := batch.Write(); err != nil {
-// 				return err
-// 			}
-// 			batch = NewBatch(db, version)
-// 		}
-// 	}
-
-// 	if batch.Size() > 0 {
-// 		if err := batch.Write(); err != nil {
-// 			return err
-// 		}
-// 	}
-
-// 	return nil
-// }
-
 // Import loads the initial version of the state in parallel with numWorkers goroutines
 // TODO: Potentially add retries instead of panics
 func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry, numWorkers int) error {

--- a/ss/rocksdb/db.go
+++ b/ss/rocksdb/db.go
@@ -254,9 +254,9 @@ func (db *Database) ReverseIterator(storeKey string, version int64, start, end [
 // }
 
 // Import loads the initial version of the state in parallel with numWorkers goroutines
+// TODO: Potentially add retries instead of panics
 func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry, numWorkers int) error {
 	var wg sync.WaitGroup
-	errChan := make(chan error, numWorkers)
 
 	worker := func() {
 		defer wg.Done()
@@ -266,15 +266,13 @@ func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry, numWork
 		for entry := range ch {
 			err := batch.Set(entry.StoreKey, entry.Key, entry.Value)
 			if err != nil {
-				errChan <- err
-				return
+				panic(err)
 			}
 
 			counter++
 			if counter%ImportCommitBatchSize == 0 {
 				if err := batch.Write(); err != nil {
-					errChan <- err
-					return
+					panic(err)
 				}
 
 				batch = NewBatch(db, version)
@@ -283,7 +281,7 @@ func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry, numWork
 
 		if batch.Size() > 0 {
 			if err := batch.Write(); err != nil {
-				errChan <- err
+				panic(err)
 			}
 		}
 	}
@@ -294,19 +292,8 @@ func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry, numWork
 	}
 
 	wg.Wait()
-	close(errChan)
 
-	if len(errChan) == 0 {
-		return nil
-	}
-
-	// Collect all errors
-	var allErrors []error
-	for err := range errChan {
-		allErrors = append(allErrors, err)
-	}
-
-	return utils.Join(allErrors...)
+	return nil
 }
 
 // newTSReadOptions returns ReadOptions used in the RocksDB column family read.

--- a/ss/setup.go
+++ b/ss/setup.go
@@ -23,6 +23,7 @@ const (
 	FlagSSAsyncWriterBuffer = "state-store.async-write-buffer"
 	FlagSSKeepRecent        = "state-store.keep-recent"
 	FlagSSPruneInterval     = "state-store.prune-interval-seconds"
+	FlagSSImportNumWorkers  = "state-store.import-num-workers"
 )
 
 func SetupStateStore(
@@ -43,6 +44,7 @@ func SetupStateStore(
 	ssBackend := cast.ToString(appOpts.Get(FlagSSBackend))
 	ssKeepRecent := cast.ToInt64(appOpts.Get(FlagSSKeepRecent))
 	ssPruneInterval := cast.ToInt64(appOpts.Get(FlagSSPruneInterval))
+	ssImportNumWorkers := cast.ToInt(appOpts.Get(FlagSSImportNumWorkers))
 	logger.Info(fmt.Sprintf("State Store is enabled with %s backend", ssBackend))
 
 	ss, err := createStateStore(homePath, BackendType(ssBackend))
@@ -75,7 +77,7 @@ func SetupStateStore(
 	pruningManager.Start()
 
 	// Setup QueryMultiStore
-	qms := store.NewMultiStore(cms, ss, exposeStoreKeys)
+	qms := store.NewMultiStore(cms, ss, exposeStoreKeys, ssImportNumWorkers)
 	qms.MountTransientStores(tkeys)
 	qms.MountMemoryStores(memKeys)
 

--- a/ss/sqlite/db.go
+++ b/ss/sqlite/db.go
@@ -236,7 +236,7 @@ func (db *Database) ReverseIterator(storeKey string, version int64, start, end [
 
 // Import loads the initial version of the state
 // TODO: Parallelize Import
-func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry) error {
+func (db *Database) Import(version int64, ch <-chan sstypes.ImportEntry, numWorkers int) error {
 	batch, err := NewBatch(db.storage, version)
 	if err != nil {
 		return err

--- a/ss/store/import.go
+++ b/ss/store/import.go
@@ -14,7 +14,7 @@ import (
 func (s *MultiStore) Restore(height uint64, _ uint32, protoReader protoio.Reader) (snapshottypes.SnapshotItem, error) {
 	ch := make(chan types.ImportEntry, 1000)
 	go func() {
-		err := s.stateStore.Import(int64(height), ch)
+		err := s.stateStore.Import(int64(height), ch, s.importNumWorkers)
 		if err != nil {
 			panic(err)
 		}

--- a/ss/store/multistore.go
+++ b/ss/store/multistore.go
@@ -28,15 +28,19 @@ type MultiStore struct {
 	traceWriter       io.Writer
 	traceContext      types.TraceContext
 	traceContextMutex sync.Mutex
+
+	// Number of goroutines for import
+	importNumWorkers int
 }
 
 // NewMultiStore returns a new state store `MultiStore`.
-func NewMultiStore(parent types.MultiStore, store sstypes.StateStore, storeKeys map[string]types.StoreKey) *MultiStore {
+func NewMultiStore(parent types.MultiStore, store sstypes.StateStore, storeKeys map[string]types.StoreKey, importNumWorkers int) *MultiStore {
 	return &MultiStore{
-		stateStore:      store,
-		storeKeys:       storeKeys,
-		parent:          parent,
-		transientStores: make(map[types.StoreKey]struct{}),
+		stateStore:       store,
+		storeKeys:        storeKeys,
+		parent:           parent,
+		transientStores:  make(map[types.StoreKey]struct{}),
+		importNumWorkers: importNumWorkers,
 	}
 }
 
@@ -116,6 +120,15 @@ func (s *MultiStore) getTracingContext() types.TraceContext {
 	}
 
 	return ctx
+}
+
+func (s *MultiStore) SetImportNumWorkers(numWorkers int) types.MultiStore {
+	s.importNumWorkers = numWorkers
+	return s
+}
+
+func (s *MultiStore) GetImportNumWorkers() int {
+	return s.importNumWorkers
 }
 
 // MountTransientStores simulates the same behavior as sdk to support grpc query service.

--- a/ss/types/types.go
+++ b/ss/types/types.go
@@ -23,7 +23,7 @@ type StateStore interface {
 	ApplyChangeset(version int64, cs *proto.NamedChangeSet) error
 
 	// Import the initial state of the store
-	Import(version int64, ch <-chan ImportEntry) error
+	Import(version int64, ch <-chan ImportEntry, numWorkers int) error
 
 	// Prune attempts to prune all versions up to and including the provided
 	// version argument. The operation should be idempotent. An error should be


### PR DESCRIPTION
## Describe your changes and provide context
- Parallelizes import
- Spins up `numWorkers` goroutines to import 
- NOTE: Did not add to sqlite since we use tx's 

## Testing performed to validate your change
- Tested on local machine parallel import, testing on node
