### PR TITLE
Perf: Improve memIAVL import speed by 2X

### DIFF
--- a/sc/memiavl/db/import.go
+++ b/sc/memiavl/db/import.go
@@ -11,7 +11,10 @@ import (
 	"github.com/sei-protocol/sei-db/proto"
 )
 
-var importBufferSize = 10000
+var (
+	nodeChanSize = 10000
+	bufIOSize    = 64 * 1024 * 1024
+)
 
 type MultiTreeImporter struct {
 	dir         string
@@ -105,7 +108,7 @@ type TreeImporter struct {
 }
 
 func NewTreeImporter(dir string, version int64) *TreeImporter {
-	nodesChan := make(chan *ExportNode, importBufferSize)
+	nodesChan := make(chan *ExportNode, nodeChanSize)
 	quitChan := make(chan error)
 	go func() {
 		defer close(quitChan)

--- a/sc/memiavl/db/import.go
+++ b/sc/memiavl/db/import.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sei-protocol/sei-db/proto"
 )
 
+var importBufferSize = 10000
+
 type MultiTreeImporter struct {
 	dir         string
 	snapshotDir string
@@ -103,7 +105,7 @@ type TreeImporter struct {
 }
 
 func NewTreeImporter(dir string, version int64) *TreeImporter {
-	nodesChan := make(chan *ExportNode)
+	nodesChan := make(chan *ExportNode, importBufferSize)
 	quitChan := make(chan error)
 	go func() {
 		defer close(quitChan)

--- a/sc/memiavl/db/snapshot.go
+++ b/sc/memiavl/db/snapshot.go
@@ -411,9 +411,9 @@ func writeSnapshot(
 		}
 	}()
 
-	nodesWriter := bufio.NewWriter(fpNodes)
-	leavesWriter := bufio.NewWriter(fpLeaves)
-	kvsWriter := bufio.NewWriter(fpKVs)
+	nodesWriter := bufio.NewWriterSize(fpNodes, bufIOSize)
+	leavesWriter := bufio.NewWriterSize(fpLeaves, bufIOSize)
+	kvsWriter := bufio.NewWriterSize(fpKVs, bufIOSize)
 
 	w := newSnapshotWriter(nodesWriter, leavesWriter, kvsWriter)
 	leaves, err := doWrite(w)

--- a/sc/memiavl/db/snapshot_test.go
+++ b/sc/memiavl/db/snapshot_test.go
@@ -180,9 +180,9 @@ func testSnapshotRoundTrip(t *testing.T, db *DB) {
 		require.NoError(t, importer.Add(item))
 	}
 
-	require.NoError(t, exporter.Close())
 	require.NoError(t, importer.Finalize())
 	require.NoError(t, importer.Close())
+	require.NoError(t, exporter.Close())
 
 	db2, err := Load(restoreDir, Options{})
 	require.NoError(t, err)


### PR DESCRIPTION
## Describe your changes and provide context
Context:
After investigating the memIAVL import performance, we find that it is spending lot of extra time waiting on the channel. Adding some buffer size for the channel will greatly improve the performance of import.

## Testing performed to validate your change
Tested on atlantic-2
