### PR TITLE
[SeiDB] Optimize Pebble Pruning Heuristic

### DIFF
--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -510,7 +510,7 @@ func parseStoreKey(key []byte) string {
 
 	// remaining format is {storeKey}/...
 	storeKeySplit := strings.Split(split[1], "/")
-	if len(storeKeySplit) != 2 {
+	if len(storeKeySplit) < 2 {
 		return ""
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
- Optimization to not iterate over store keys in pruning if the store has not been updated 
- Maintains a sync.Map storing the last time each module was last updated. If a module's last update is not greater than the last prune height, then we can skip all the keys for that module (it hasn't been updated since the last pruning)

## Testing performed to validate your change
- Tested locally with benchmark, testing on node
