### PR TITLE
[SeiDB] Fix PebbleDB Iterator Issue

### DIFF
--- a/ss/pebbledb/comparator.go
+++ b/ss/pebbledb/comparator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/sei-protocol/sei-db/common/utils"
 )
 
 // MVCCComparer returns a PebbleDB Comparer with encoding and decoding routines
@@ -145,7 +146,7 @@ func SplitMVCCKey(mvccKey []byte) (key, version []byte, ok bool) {
 		return nil, nil, false
 	}
 
-	mvccKeyCopy := bytes.Clone(mvccKey)
+	mvccKeyCopy := utils.Clone(mvccKey)
 
 	n := len(mvccKeyCopy) - 1
 	tsLen := int(mvccKeyCopy[n])

--- a/ss/pebbledb/comparator.go
+++ b/ss/pebbledb/comparator.go
@@ -137,20 +137,25 @@ func (f mvccKeyFormatter) Format(s fmt.State, verb rune) {
 
 // SplitMVCCKey accepts an MVCC key and returns the "user" key, the MVCC version,
 // and a boolean indicating if the provided key is an MVCC key.
+//
+// Note, internally, we must make a copy of the provided mvccKey argument, which
+// typically comes from the Key() method as it's not safe.
 func SplitMVCCKey(mvccKey []byte) (key, version []byte, ok bool) {
 	if len(mvccKey) == 0 {
 		return nil, nil, false
 	}
 
-	n := len(mvccKey) - 1
-	tsLen := int(mvccKey[n])
+	mvccKeyCopy := bytes.Clone(mvccKey)
+
+	n := len(mvccKeyCopy) - 1
+	tsLen := int(mvccKeyCopy[n])
 	if n < tsLen {
 		return nil, nil, false
 	}
 
-	key = mvccKey[:n-tsLen]
+	key = mvccKeyCopy[:n-tsLen]
 	if tsLen > 0 {
-		version = mvccKey[n-tsLen+1 : len(mvccKey)-1]
+		version = mvccKeyCopy[n-tsLen+1 : len(mvccKeyCopy)-1]
 	}
 
 	return key, version, true

--- a/ss/pebbledb/iterator.go
+++ b/ss/pebbledb/iterator.go
@@ -116,15 +116,15 @@ func (itr *iterator) Value() []byte {
 }
 
 func (itr *iterator) Next() {
+	currKey, _, ok := SplitMVCCKey(itr.source.Key())
+	if !ok {
+		// XXX: This should not happen as that would indicate we have a malformed
+		// MVCC key.
+		panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
+	}
+
 	var next bool
 	if itr.reverse {
-		currKey, _, ok := SplitMVCCKey(itr.source.Key())
-		if !ok {
-			// XXX: This should not happen as that would indicate we have a malformed
-			// MVCC key.
-			panic(fmt.Sprintf("invalid PebbleDB MVCC key: %s", itr.source.Key()))
-		}
-
 		// Since PebbleDB has no PrevPrefix API, we must manually seek to the next
 		// key that is lexicographically less than the current key.
 		next = itr.source.SeekLT(MVCCEncode(currKey, 0))
@@ -153,6 +153,27 @@ func (itr *iterator) Next() {
 		// Move the iterator to the closest version to the desired version, so we
 		// append the current iterator key to the prefix and seek to that key.
 		itr.valid = itr.source.SeekLT(MVCCEncode(nextKey, itr.version+1))
+
+		tmpKey, _, ok := SplitMVCCKey(itr.source.Key())
+		if !ok {
+			// XXX: This should not happen as that would indicate we have a malformed
+			// MVCC key.
+			itr.valid = false
+			return
+		}
+
+		// There exists cases where the SeekLT() call moved us back to the same key
+		// we started at, so we must move to next key, i.e. two keys forward.
+		if bytes.Equal(tmpKey, currKey) {
+			if itr.source.SeekGE(MVCCEncode(nextKey, 0)) {
+				if itr.source.NextPrefix() {
+					itr.Next()
+				}
+			}
+
+			itr.valid = false
+			return
+		}
 
 		// The cursor might now be pointing at a key/value pair that is tombstoned.
 		// If so, we must move the cursor.

--- a/ss/pebbledb/iterator.go
+++ b/ss/pebbledb/iterator.go
@@ -167,10 +167,10 @@ func (itr *iterator) Next() {
 		if bytes.Equal(tmpKey, currKey) {
 			if itr.source.NextPrefix() {
 				itr.Next()
+			} else {
+				itr.valid = false
+				return
 			}
-
-			itr.valid = false
-			return
 		}
 
 		// The cursor might now be pointing at a key/value pair that is tombstoned.

--- a/ss/pebbledb/iterator.go
+++ b/ss/pebbledb/iterator.go
@@ -165,10 +165,8 @@ func (itr *iterator) Next() {
 		// There exists cases where the SeekLT() call moved us back to the same key
 		// we started at, so we must move to next key, i.e. two keys forward.
 		if bytes.Equal(tmpKey, currKey) {
-			if itr.source.SeekGE(MVCCEncode(nextKey, 0)) {
-				if itr.source.NextPrefix() {
-					itr.Next()
-				}
+			if itr.source.NextPrefix() {
+				itr.Next()
 			}
 
 			itr.valid = false

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -375,6 +375,7 @@ func (s *StorageTestSuite) TestDatabaseIteratorLooping() {
 	s.Require().NoError(err)
 	defer db.Close()
 
+	// Forward Iteration
 	// Less than iterator version
 	s.Require().NoError(DBApplyChangeset(db, 58827506, storeKey1, [][]byte{[]byte("keyC")}, [][]byte{[]byte("value003")}))
 	// Both below are greater
@@ -382,6 +383,10 @@ func (s *StorageTestSuite) TestDatabaseIteratorLooping() {
 	s.Require().NoError(DBApplyChangeset(db, 58833606, storeKey1, [][]byte{[]byte("keyD")}, [][]byte{[]byte("value006")}))
 	s.Require().NoError(DBApplyChangeset(db, 58827507, storeKey1, [][]byte{[]byte("keyE")}, [][]byte{[]byte("value006")}))
 	s.Require().NoError(DBApplyChangeset(db, 58827508, storeKey1, [][]byte{[]byte("keyF")}, [][]byte{[]byte("value007")}))
+	// Another case of a loop
+	s.Require().NoError(DBApplyChangeset(db, 58827509, storeKey1, [][]byte{[]byte("keyG")}, [][]byte{[]byte("value008")}))
+	s.Require().NoError(DBApplyChangeset(db, 58831545, storeKey1, [][]byte{[]byte("keyG")}, [][]byte{[]byte("value009")}))
+	s.Require().NoError(DBApplyChangeset(db, 58831565, storeKey1, [][]byte{[]byte("keyH")}, [][]byte{[]byte("value010")}))
 
 	itr, err := db.Iterator(storeKey1, 58831525, []byte("keyA"), nil)
 	s.Require().NoError(err)
@@ -393,7 +398,20 @@ func (s *StorageTestSuite) TestDatabaseIteratorLooping() {
 		count++
 	}
 
-	s.Require().Equal(3, count)
+	s.Require().Equal(4, count)
+
+	// Reverse Iteration
+	itr, err = db.Iterator(storeKey1, 58831525, nil, []byte("keyZ"))
+	s.Require().NoError(err)
+
+	defer itr.Close()
+
+	count = 0
+	for ; itr.Valid(); itr.Next() {
+		count++
+	}
+
+	s.Require().Equal(4, count)
 }
 
 func (s *StorageTestSuite) TestDatabaseIteratorNoDomain() {

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -2,13 +2,9 @@ package sstest
 
 import (
 	"fmt"
-	"sync"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/cosmos/iavl"
 	"github.com/sei-protocol/sei-db/ss/types"
 )
 
@@ -25,326 +21,317 @@ type StorageTestSuite struct {
 	SkipTests      []string
 }
 
-func (s *StorageTestSuite) TestDatabaseClose() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	s.Require().NoError(db.Close())
+// func (s *StorageTestSuite) TestDatabaseClose() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	s.Require().NoError(db.Close())
 
-	// close should not be idempotent
-	s.Require().Panics(func() { _ = db.Close() })
-}
+// 	// close should not be idempotent
+// 	s.Require().Panics(func() { _ = db.Close() })
+// }
 
-func (s *StorageTestSuite) TestDatabaseLatestVersion() {
-	tempDir := s.T().TempDir()
-	db, err := s.NewDB(tempDir)
-	s.Require().NoError(err)
+// func (s *StorageTestSuite) TestDatabaseLatestVersion() {
+// 	tempDir := s.T().TempDir()
+// 	db, err := s.NewDB(tempDir)
+// 	s.Require().NoError(err)
 
-	lv, err := db.GetLatestVersion()
-	s.Require().NoError(err)
-	s.Require().Zero(lv)
+// 	lv, err := db.GetLatestVersion()
+// 	s.Require().NoError(err)
+// 	s.Require().Zero(lv)
 
-	i := int64(1)
-	for ; i <= 1001; i++ {
-		err = db.SetLatestVersion(i)
-		s.Require().NoError(err)
+// 	i := int64(1)
+// 	for ; i <= 1001; i++ {
+// 		err = db.SetLatestVersion(i)
+// 		s.Require().NoError(err)
 
-		lv, err = db.GetLatestVersion()
-		s.Require().NoError(err)
-		s.Require().Equal(i, lv)
-	}
+// 		lv, err = db.GetLatestVersion()
+// 		s.Require().NoError(err)
+// 		s.Require().Equal(i, lv)
+// 	}
 
-	// Test even after closing and reopening, the latest version is maintained
-	err = db.Close()
-	s.Require().NoError(err)
+// 	// Test even after closing and reopening, the latest version is maintained
+// 	err = db.Close()
+// 	s.Require().NoError(err)
 
-	newDB, err := s.NewDB(tempDir)
-	s.Require().NoError(err)
-	defer newDB.Close()
+// 	newDB, err := s.NewDB(tempDir)
+// 	s.Require().NoError(err)
+// 	defer newDB.Close()
 
-	lv, err = newDB.GetLatestVersion()
-	s.Require().NoError(err)
-	s.Require().Equal(i-1, lv)
+// 	lv, err = newDB.GetLatestVersion()
+// 	s.Require().NoError(err)
+// 	s.Require().Equal(i-1, lv)
 
-}
+// }
 
-func (s *StorageTestSuite) TestDatabaseVersionedKeys() {
+// func (s *StorageTestSuite) TestDatabaseVersionedKeys() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 1, 100))
+
+// 	for i := int64(1); i <= 100; i++ {
+// 		bz, err := db.Get(storeKey1, i, []byte("key000"))
+// 		s.Require().NoError(err)
+// 		s.Require().Equal(fmt.Sprintf("val000-%03d", i), string(bz))
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestDatabaseGetVersionedKey() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	key := []byte("key")
+// 	val := []byte("value001")
+
+// 	// store a key at version 1
+// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{val}))
+
+// 	// assume chain progresses to version 10 w/o any changes to key
+// 	bz, err := db.Get(storeKey1, 10, key)
+// 	s.Require().NoError(err)
+// 	s.Require().Equal(val, bz)
+
+// 	ok, err := db.Has(storeKey1, 10, key)
+// 	s.Require().NoError(err)
+// 	s.Require().True(ok)
+
+// 	// chain progresses to version 11 with an update to key
+// 	newVal := []byte("value011")
+// 	s.Require().NoError(DBApplyChangeset(db, 11, storeKey1, [][]byte{key}, [][]byte{newVal}))
+
+// 	bz, err = db.Get(storeKey1, 10, key)
+// 	s.Require().NoError(err)
+// 	s.Require().Equal(val, bz)
+
+// 	ok, err = db.Has(storeKey1, 10, key)
+// 	s.Require().NoError(err)
+// 	s.Require().True(ok)
+
+// 	for i := int64(11); i <= 14; i++ {
+// 		bz, err = db.Get(storeKey1, i, key)
+// 		s.Require().NoError(err)
+// 		s.Require().Equal(newVal, bz)
+
+// 		ok, err = db.Has(storeKey1, i, key)
+// 		s.Require().NoError(err)
+// 		s.Require().True(ok)
+// 	}
+
+// 	// chain progresses to version 15 with a delete to key
+// 	s.Require().NoError(DBApplyChangeset(db, 15, storeKey1, [][]byte{key}, [][]byte{nil}))
+
+// 	// all queries up to version 14 should return the latest value
+// 	for i := int64(1); i <= 14; i++ {
+// 		bz, err = db.Get(storeKey1, i, key)
+// 		s.Require().NoError(err)
+// 		s.Require().NotNil(bz)
+
+// 		ok, err = db.Has(storeKey1, i, key)
+// 		s.Require().NoError(err)
+// 		s.Require().True(ok)
+// 	}
+
+// 	// all queries after version 15 should return nil
+// 	for i := int64(15); i <= 17; i++ {
+// 		bz, err = db.Get(storeKey1, i, key)
+// 		s.Require().NoError(err)
+// 		s.Require().Nil(bz)
+
+// 		ok, err = db.Has(storeKey1, i, key)
+// 		s.Require().NoError(err)
+// 		s.Require().False(ok)
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestDatabaseApplyChangeset() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 100, 1))
+
+// 	cs := &iavl.ChangeSet{}
+// 	cs.Pairs = []*iavl.KVPair{}
+
+// 	// Deletes
+// 	keys := [][]byte{}
+// 	vals := [][]byte{}
+// 	for i := 0; i < 100; i++ {
+// 		if i%10 == 0 {
+// 			keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
+// 			vals = append(vals, nil)
+// 		}
+// 	}
+// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, keys, vals))
+
+// 	lv, err := db.GetLatestVersion()
+// 	s.Require().NoError(err)
+// 	s.Require().Equal(int64(1), lv)
+
+// 	for i := 0; i < 100; i++ {
+// 		ok, err := db.Has(storeKey1, 1, []byte(fmt.Sprintf("key%03d", i)))
+// 		s.Require().NoError(err)
+
+// 		if i%10 == 0 {
+// 			s.Require().False(ok)
+// 		} else {
+// 			s.Require().True(ok)
+// 		}
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestDatabaseIteratorEmptyDomain() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	iter, err := db.Iterator(storeKey1, 1, []byte{}, []byte{})
+// 	s.Require().Error(err)
+// 	s.Require().Nil(iter)
+// }
+
+// func (s *StorageTestSuite) TestDatabaseIteratorClose() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	iter, err := db.Iterator(storeKey1, 1, []byte("key000"), nil)
+// 	s.Require().NoError(err)
+// 	iter.Close()
+
+// 	s.Require().False(iter.Valid())
+// 	s.Require().Panics(func() { iter.Close() })
+// }
+
+// func (s *StorageTestSuite) TestDatabaseIteratorDomain() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	testCases := map[string]struct {
+// 		start, end []byte
+// 	}{
+// 		"start without end domain": {
+// 			start: []byte("key010"),
+// 		},
+// 		"start and end domain": {
+// 			start: []byte("key010"),
+// 			end:   []byte("key020"),
+// 		},
+// 	}
+
+// 	for name, tc := range testCases {
+// 		s.Run(name, func() {
+// 			iter, err := db.Iterator(storeKey1, 1, tc.start, tc.end)
+// 			s.Require().NoError(err)
+
+// 			defer iter.Close()
+
+// 			start, end := iter.Domain()
+// 			s.Require().Equal(tc.start, start)
+// 			s.Require().Equal(tc.end, end)
+// 		})
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestDatabaseIterator() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 100, 1))
+
+// 	// iterator without an end key over multiple versions
+// 	for v := int64(1); v < 5; v++ {
+// 		itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
+// 		s.Require().NoError(err)
+
+// 		defer itr.Close()
+
+// 		var i, count int
+// 		for ; itr.Valid(); itr.Next() {
+// 			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr.Value())
+
+// 			i++
+// 			count++
+// 		}
+// 		s.Require().Equal(100, count)
+// 		s.Require().NoError(itr.Error())
+
+// 		// seek past domain, which should make the iterator invalid and produce an error
+// 		itr.Next()
+// 		s.Require().False(itr.Valid())
+// 	}
+
+// 	// iterator with with a start and end domain over multiple versions
+// 	for v := int64(1); v < 5; v++ {
+// 		itr2, err := db.Iterator(storeKey1, v, []byte("key010"), []byte("key019"))
+// 		s.Require().NoError(err)
+
+// 		defer itr2.Close()
+
+// 		i, count := 10, 0
+// 		for ; itr2.Valid(); itr2.Next() {
+// 			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr2.Key())
+// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr2.Value())
+
+// 			i++
+// 			count++
+// 		}
+// 		s.Require().Equal(9, count)
+// 		s.Require().NoError(itr2.Error())
+
+// 		// seek past domain, which should make the iterator invalid and produce an error
+// 		itr2.Next()
+// 		s.Require().False(itr2.Valid())
+// 	}
+
+// 	// start must be <= end
+// 	iter3, err := db.Iterator(storeKey1, 1, []byte("key020"), []byte("key019"))
+// 	s.Require().Error(err)
+// 	s.Require().Nil(iter3)
+// }
+
+// func (s *StorageTestSuite) TestDatabaseIteratorRangedDeletes() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key001")}, [][]byte{[]byte("value001")}))
+// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value001")}))
+// 	s.Require().NoError(DBApplyChangeset(db, 5, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value002")}))
+// 	s.Require().NoError(DBApplyChangeset(db, 10, storeKey1, [][]byte{[]byte("key002")}, [][]byte{nil}))
+
+// 	itr, err := db.Iterator(storeKey1, 11, []byte("key001"), nil)
+// 	s.Require().NoError(err)
+
+// 	defer itr.Close()
+
+// 	// there should only be one valid key in the iterator -- key001
+// 	var count int
+// 	for ; itr.Valid(); itr.Next() {
+// 		s.Require().Equal([]byte("key001"), itr.Key())
+// 		count++
+// 	}
+// 	s.Require().Equal(1, count)
+// 	s.Require().NoError(itr.Error())
+// }
+
+func (s *StorageTestSuite) TestDatabaseIteratorBug() {
 	db, err := s.NewDB(s.T().TempDir())
 	s.Require().NoError(err)
 	defer db.Close()
 
-	s.Require().NoError(FillData(db, 1, 100))
+	// Less than iterator version
+	s.Require().NoError(DBApplyChangeset(db, 58827506, storeKey1, [][]byte{[]byte("keyC")}, [][]byte{[]byte("value003")}))
+	// Both below are greater
+	s.Require().NoError(DBApplyChangeset(db, 58833605, storeKey1, [][]byte{[]byte("keyC")}, [][]byte{[]byte("value004")}))
+	s.Require().NoError(DBApplyChangeset(db, 58827507, storeKey1, [][]byte{[]byte("keyD")}, [][]byte{[]byte("value006")}))
 
-	for i := int64(1); i <= 100; i++ {
-		bz, err := db.Get(storeKey1, i, []byte("key000"))
-		s.Require().NoError(err)
-		s.Require().Equal(fmt.Sprintf("val000-%03d", i), string(bz))
-	}
-}
-
-func (s *StorageTestSuite) TestDatabaseGetVersionedKey() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	key := []byte("key")
-	val := []byte("value001")
-
-	// store a key at version 1
-	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{val}))
-
-	// assume chain progresses to version 10 w/o any changes to key
-	bz, err := db.Get(storeKey1, 10, key)
-	s.Require().NoError(err)
-	s.Require().Equal(val, bz)
-
-	ok, err := db.Has(storeKey1, 10, key)
-	s.Require().NoError(err)
-	s.Require().True(ok)
-
-	// chain progresses to version 11 with an update to key
-	newVal := []byte("value011")
-	s.Require().NoError(DBApplyChangeset(db, 11, storeKey1, [][]byte{key}, [][]byte{newVal}))
-
-	bz, err = db.Get(storeKey1, 10, key)
-	s.Require().NoError(err)
-	s.Require().Equal(val, bz)
-
-	ok, err = db.Has(storeKey1, 10, key)
-	s.Require().NoError(err)
-	s.Require().True(ok)
-
-	for i := int64(11); i <= 14; i++ {
-		bz, err = db.Get(storeKey1, i, key)
-		s.Require().NoError(err)
-		s.Require().Equal(newVal, bz)
-
-		ok, err = db.Has(storeKey1, i, key)
-		s.Require().NoError(err)
-		s.Require().True(ok)
-	}
-
-	// chain progresses to version 15 with a delete to key
-	s.Require().NoError(DBApplyChangeset(db, 15, storeKey1, [][]byte{key}, [][]byte{nil}))
-
-	// all queries up to version 14 should return the latest value
-	for i := int64(1); i <= 14; i++ {
-		bz, err = db.Get(storeKey1, i, key)
-		s.Require().NoError(err)
-		s.Require().NotNil(bz)
-
-		ok, err = db.Has(storeKey1, i, key)
-		s.Require().NoError(err)
-		s.Require().True(ok)
-	}
-
-	// all queries after version 15 should return nil
-	for i := int64(15); i <= 17; i++ {
-		bz, err = db.Get(storeKey1, i, key)
-		s.Require().NoError(err)
-		s.Require().Nil(bz)
-
-		ok, err = db.Has(storeKey1, i, key)
-		s.Require().NoError(err)
-		s.Require().False(ok)
-	}
-}
-
-func (s *StorageTestSuite) TestDatabaseApplyChangeset() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 100, 1))
-
-	cs := &iavl.ChangeSet{}
-	cs.Pairs = []*iavl.KVPair{}
-
-	// Deletes
-	keys := [][]byte{}
-	vals := [][]byte{}
-	for i := 0; i < 100; i++ {
-		if i%10 == 0 {
-			keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
-			vals = append(vals, nil)
-		}
-	}
-	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, keys, vals))
-
-	lv, err := db.GetLatestVersion()
-	s.Require().NoError(err)
-	s.Require().Equal(int64(1), lv)
-
-	for i := 0; i < 100; i++ {
-		ok, err := db.Has(storeKey1, 1, []byte(fmt.Sprintf("key%03d", i)))
-		s.Require().NoError(err)
-
-		if i%10 == 0 {
-			s.Require().False(ok)
-		} else {
-			s.Require().True(ok)
-		}
-	}
-}
-
-func (s *StorageTestSuite) TestDatabaseIteratorEmptyDomain() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	iter, err := db.Iterator(storeKey1, 1, []byte{}, []byte{})
-	s.Require().Error(err)
-	s.Require().Nil(iter)
-}
-
-func (s *StorageTestSuite) TestDatabaseIteratorClose() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	iter, err := db.Iterator(storeKey1, 1, []byte("key000"), nil)
-	s.Require().NoError(err)
-	iter.Close()
-
-	s.Require().False(iter.Valid())
-	s.Require().Panics(func() { iter.Close() })
-}
-
-func (s *StorageTestSuite) TestDatabaseIteratorDomain() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	testCases := map[string]struct {
-		start, end []byte
-	}{
-		"start without end domain": {
-			start: []byte("key010"),
-		},
-		"start and end domain": {
-			start: []byte("key010"),
-			end:   []byte("key020"),
-		},
-	}
-
-	for name, tc := range testCases {
-		s.Run(name, func() {
-			iter, err := db.Iterator(storeKey1, 1, tc.start, tc.end)
-			s.Require().NoError(err)
-
-			defer iter.Close()
-
-			start, end := iter.Domain()
-			s.Require().Equal(tc.start, start)
-			s.Require().Equal(tc.end, end)
-		})
-	}
-}
-
-func (s *StorageTestSuite) TestDatabaseIterator() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 100, 1))
-
-	// iterator without an end key over multiple versions
-	for v := int64(1); v < 5; v++ {
-		itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
-		s.Require().NoError(err)
-
-		defer itr.Close()
-
-		var i, count int
-		for ; itr.Valid(); itr.Next() {
-			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr.Value())
-
-			i++
-			count++
-		}
-		s.Require().Equal(100, count)
-		s.Require().NoError(itr.Error())
-
-		// seek past domain, which should make the iterator invalid and produce an error
-		itr.Next()
-		s.Require().False(itr.Valid())
-	}
-
-	// iterator with with a start and end domain over multiple versions
-	for v := int64(1); v < 5; v++ {
-		itr2, err := db.Iterator(storeKey1, v, []byte("key010"), []byte("key019"))
-		s.Require().NoError(err)
-
-		defer itr2.Close()
-
-		i, count := 10, 0
-		for ; itr2.Valid(); itr2.Next() {
-			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr2.Key())
-			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr2.Value())
-
-			i++
-			count++
-		}
-		s.Require().Equal(9, count)
-		s.Require().NoError(itr2.Error())
-
-		// seek past domain, which should make the iterator invalid and produce an error
-		itr2.Next()
-		s.Require().False(itr2.Valid())
-	}
-
-	// start must be <= end
-	iter3, err := db.Iterator(storeKey1, 1, []byte("key020"), []byte("key019"))
-	s.Require().Error(err)
-	s.Require().Nil(iter3)
-}
-
-func (s *StorageTestSuite) TestDatabaseIteratorRangedDeletes() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key001")}, [][]byte{[]byte("value001")}))
-	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value001")}))
-	s.Require().NoError(DBApplyChangeset(db, 5, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value002")}))
-	s.Require().NoError(DBApplyChangeset(db, 10, storeKey1, [][]byte{[]byte("key002")}, [][]byte{nil}))
-
-	itr, err := db.Iterator(storeKey1, 11, []byte("key001"), nil)
-	s.Require().NoError(err)
-
-	defer itr.Close()
-
-	// there should only be one valid key in the iterator -- key001
-	var count int
-	for ; itr.Valid(); itr.Next() {
-		s.Require().Equal([]byte("key001"), itr.Key())
-		count++
-	}
-	s.Require().Equal(1, count)
-	s.Require().NoError(itr.Error())
-}
-
-func (s *StorageTestSuite) TestDatabaseIteratorMultiVersion() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 10, 50))
-
-	// for versions 50-100, only update even keys
-	for v := int64(51); v <= 100; v++ {
-		keys := [][]byte{}
-		vals := [][]byte{}
-		for i := 0; i < 10; i++ {
-			if i%2 == 0 {
-				keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
-				vals = append(vals, []byte(fmt.Sprintf("val%03d-%03d", i, v)))
-			}
-		}
-		s.Require().NoError(DBApplyChangeset(db, v, storeKey1, keys, vals))
-	}
-
-	itr, err := db.Iterator(storeKey1, 69, []byte("key000"), nil)
+	itr, err := db.Iterator(storeKey1, 58831525, []byte("keyA"), nil)
 	s.Require().NoError(err)
 
 	defer itr.Close()
@@ -352,565 +339,599 @@ func (s *StorageTestSuite) TestDatabaseIteratorMultiVersion() {
 	// All keys should be present; All odd keys should have a value that reflects
 	// version 49, and all even keys should have a value that reflects the desired
 	// version, 69.
-	var i, count int
 	for ; itr.Valid(); itr.Next() {
-		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-
-		if i%2 == 0 {
-			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 69)), itr.Value())
-		} else {
-			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
-		}
-
-		i = (i + 1) % 10
-		count++
+		fmt.Printf("itr key %s valid %+v\n", string(itr.Key()), itr.Valid())
 	}
-	s.Require().Equal(10, count)
-	s.Require().NoError(itr.Error())
+
 }
 
-func (s *StorageTestSuite) TestDatabaseIteratorNoDomain() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 10, 50))
-
-	// create an iterator over the entire domain
-	itr, err := db.Iterator(storeKey1, 50, nil, nil)
-	s.Require().NoError(err)
-
-	defer itr.Close()
-
-	var i, count int
-	for ; itr.Valid(); itr.Next() {
-		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-		s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
-
-		i++
-		count++
-	}
-	s.Require().Equal(10, count)
-	s.Require().NoError(itr.Error())
-}
-
-func (s *StorageTestSuite) TestDatabasePrune() {
-	if slices.Contains(s.SkipTests, s.T().Name()) {
-		s.T().SkipNow()
-	}
-
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 10, 50))
-
-	// prune the first 25 versions
-	s.Require().NoError(db.Prune(25))
-
-	latestVersion, err := db.GetLatestVersion()
-	s.Require().NoError(err)
-	s.Require().Equal(int64(50), latestVersion)
-
-	// Ensure all keys are no longer present up to and including version 25 and
-	// all keys are present after version 25.
-	for v := int64(1); v <= 50; v++ {
-		for i := 0; i < 10; i++ {
-			key := fmt.Sprintf("key%03d", i)
-			val := fmt.Sprintf("val%03d-%03d", i, v)
-
-			bz, err := db.Get(storeKey1, v, []byte(key))
-			s.Require().NoError(err)
-			if v <= 25 {
-				s.Require().Nil(bz)
-			} else {
-				s.Require().Equal([]byte(val), bz)
-			}
-		}
-	}
-
-	itr, err := db.Iterator(storeKey1, 25, []byte("key000"), nil)
-	s.Require().NoError(err)
-	s.Require().False(itr.Valid())
-
-	// prune the latest version which should prune the entire dataset
-	s.Require().NoError(db.Prune(50))
-
-	for v := int64(1); v <= 50; v++ {
-		for i := 0; i < 10; i++ {
-			key := fmt.Sprintf("key%03d", i)
-
-			bz, err := db.Get(storeKey1, v, []byte(key))
-			s.Require().NoError(err)
-			s.Require().Nil(bz)
-		}
-	}
-}
-
-func (s *StorageTestSuite) TestDatabasePruneKeepRecent() {
-	if slices.Contains(s.SkipTests, s.T().Name()) {
-		s.T().SkipNow()
-	}
-
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	key := []byte("key000")
-
-	// write a key at three different versions 1, 100 and 200
-	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{[]byte("value001")}))
-	s.Require().NoError(DBApplyChangeset(db, 100, storeKey1, [][]byte{key}, [][]byte{[]byte("value002")}))
-	s.Require().NoError(DBApplyChangeset(db, 200, storeKey1, [][]byte{key}, [][]byte{[]byte("value003")}))
-
-	// prune version 50
-	s.Require().NoError(db.Prune(50))
-
-	// ensure queries for versions 50 and older return nil
-	bz, err := db.Get(storeKey1, 49, key)
-	s.Require().Nil(err)
-	s.Require().Nil(bz)
-
-	itr, err := db.Iterator(storeKey1, 49, nil, nil)
-	s.Require().NoError(err)
-	s.Require().False(itr.Valid())
-
-	defer itr.Close()
-
-	// ensure the value previously at version 1 is still there for queries greater than 50
-	bz, err = db.Get(storeKey1, 51, key)
-	s.Require().NoError(err)
-	s.Require().Equal([]byte("value001"), bz)
-
-	// ensure the correct value at a greater height
-	bz, err = db.Get(storeKey1, 200, key)
-	s.Require().NoError(err)
-	s.Require().Equal([]byte("value003"), bz)
-
-	// prune latest height and ensure we have the previous version when querying above it
-	s.Require().NoError(db.Prune(200))
-
-	bz, err = db.Get(storeKey1, 201, key)
-	s.Require().NoError(err)
-	s.Require().Equal([]byte("value003"), bz)
-}
-
-func (s *StorageTestSuite) TestDatabaseReverseIterator() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 100, 1))
-
-	// reverse iterator without an end key
-	iter, err := db.ReverseIterator(storeKey1, 1, []byte("key000"), nil)
-	s.Require().NoError(err)
-
-	defer iter.Close()
-
-	i, count := 99, 0
-	for ; iter.Valid(); iter.Next() {
-		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter.Key())
-		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter.Value())
-
-		i--
-		count++
-	}
-	s.Require().Equal(100, count)
-	s.Require().NoError(iter.Error())
-
-	// seek past domain, which should make the iterator invalid and produce an error
-	iter.Next()
-	s.Require().False(iter.Valid())
-
-	// reverse iterator with with a start and end domain
-	iter2, err := db.ReverseIterator(storeKey1, 1, []byte("key010"), []byte("key019"))
-	s.Require().NoError(err)
-
-	defer iter2.Close()
-
-	i, count = 18, 0
-	for ; iter2.Valid(); iter2.Next() {
-		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter2.Key())
-		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter2.Value())
-
-		i--
-		count++
-	}
-	s.Require().Equal(9, count)
-	s.Require().NoError(iter2.Error())
-
-	// seek past domain, which should make the iterator invalid and produce an error
-	iter2.Next()
-	s.Require().False(iter2.Valid())
-
-	// start must be <= end
-	iter3, err := db.ReverseIterator(storeKey1, 1, []byte("key020"), []byte("key019"))
-	s.Require().Error(err)
-	s.Require().Nil(iter3)
-}
-
-func (s *StorageTestSuite) TestParallelWrites() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	latestVersion := 10
-	kvCount := 100
-
-	wg := sync.WaitGroup{}
-	triggerStartCh := make(chan bool)
-
-	// start 10 goroutines that write to the database
-	for i := 0; i < latestVersion; i++ {
-		wg.Add(1)
-		go func(i int) {
-			<-triggerStartCh
-			defer wg.Done()
-			keys := [][]byte{}
-			vals := [][]byte{}
-			for j := 0; j < kvCount; j++ {
-				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
-				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
-			}
-			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
-		}(i)
-
-	}
-
-	// start the goroutines
-	close(triggerStartCh)
-	wg.Wait()
-
-	// check that all the data is there
-	for i := 0; i < latestVersion; i++ {
-		for j := 0; j < kvCount; j++ {
-			version := int64(i + 1)
-			key := fmt.Sprintf("key-%d-%03d", i, j)
-			val := fmt.Sprintf("val-%d-%03d", i, j)
-
-			v, err := db.Get(storeKey1, version, []byte(key))
-			s.Require().NoError(err)
-			s.Require().Equal([]byte(val), v)
-		}
-	}
-}
-
-func (s *StorageTestSuite) TestParallelWriteAndPruning() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	latestVersion := 100
-	kvCount := 100
-	prunePeriod := 5
-
-	wg := sync.WaitGroup{}
-	triggerStartCh := make(chan bool)
-
-	// start a goroutine that write to the database
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-		for i := 0; i < latestVersion; i++ {
-			keys := [][]byte{}
-			vals := [][]byte{}
-			for j := 0; j < kvCount; j++ {
-				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
-				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
-			}
-			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
-		}
-	}()
-
-	// start a goroutine that prunes the database
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-		for i := 10; i < latestVersion; i += prunePeriod {
-			for {
-				v, err := db.GetLatestVersion()
-				s.Require().NoError(err)
-				if v > int64(i) {
-					s.Require().NoError(db.Prune(v - 1))
-					break
-				}
-			}
-		}
-	}()
-
-	// wait for the goroutines
-	close(triggerStartCh)
-	wg.Wait()
-
-	// check if the data is pruned
-	version := int64(latestVersion - prunePeriod)
-	val, err := db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
-	s.Require().Nil(err)
-	s.Require().Nil(val)
-
-	version = int64(latestVersion)
-	val, err = db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
-	s.Require().NoError(err)
-	s.Require().Equal([]byte(fmt.Sprintf("val-%d-%03d", version-1, 0)), val)
-}
-
-func (s *StorageTestSuite) TestDatabaseParallelDeleteIteration() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 100, 100))
-
-	wg := sync.WaitGroup{}
-	triggerStartCh := make(chan bool)
-
-	latestVersion := 100
-	kvCount := 100
-
-	// start a goroutine that deletes from the database at latest Version
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-
-		for j := 0; j < kvCount; j++ {
-			if j%10 == 0 {
-				key := []byte(fmt.Sprintf("key%03d", j))
-				s.Require().NoError(DBApplyChangeset(db, int64(latestVersion), storeKey1, [][]byte{key}, [][]byte{nil}))
-			}
-		}
-	}()
-
-	// start a goroutine that iterates over the database
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-		// iterator without an end key over multiple versions
-		for v := int64(1); v < 5; v++ {
-			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
-			s.Require().NoError(err)
-
-			defer itr.Close()
-
-			var i, count int
-			for ; itr.Valid(); itr.Next() {
-				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
-
-				i++
-				count++
-			}
-			s.Require().Equal(100, count)
-			s.Require().NoError(itr.Error())
-
-			// seek past domain, which should make the iterator invalid and produce an error
-			itr.Next()
-			s.Require().False(itr.Valid())
-		}
-	}()
-
-	// wait for the goroutines
-	close(triggerStartCh)
-	wg.Wait()
-
-	// Verify deletes
-	for j := 0; j < 100; j++ {
-		ok, err := db.Has(storeKey1, int64(latestVersion), []byte(fmt.Sprintf("key%03d", j)))
-		s.Require().NoError(err)
-
-		if j%10 == 0 {
-			s.Require().False(ok)
-		} else {
-			s.Require().True(ok)
-		}
-	}
-}
-
-func (s *StorageTestSuite) TestDatabaseParallelWriteDelete() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 100, 1))
-
-	wg := sync.WaitGroup{}
-	triggerStartCh := make(chan bool)
-
-	latestVersion := int64(2)
-
-	// start a goroutine that writes to the database at latestVersion
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-
-		cs := &iavl.ChangeSet{}
-		cs.Pairs = []*iavl.KVPair{}
-
-		for i := 0; i < 50; i++ {
-			// Apply changeset for each key separately
-			key := []byte(fmt.Sprintf("key%03d", i))
-			val := []byte(fmt.Sprintf("val%03d", i))
-			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{val}))
-		}
-	}()
-
-	// start a goroutine that deletes from the database
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-
-		cs := &iavl.ChangeSet{}
-		cs.Pairs = []*iavl.KVPair{}
-
-		for i := 50; i < 100; i++ {
-			// Apply changeset for each key separately
-			key := []byte(fmt.Sprintf("key%03d", i))
-			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{nil}))
-		}
-	}()
-
-	// wait for the goroutines
-	close(triggerStartCh)
-	wg.Wait()
-
-	// Verify writes and deletes on latest version
-	for j := 0; j < 100; j++ {
-		ok, err := db.Has(storeKey1, latestVersion, []byte(fmt.Sprintf("key%03d", j)))
-		s.Require().NoError(err)
-
-		if j >= 50 {
-			s.Require().False(ok)
-		} else {
-			s.Require().True(ok)
-		}
-	}
-}
-
-func (s *StorageTestSuite) TestParallelIterationAndPruning() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 10, 50))
-
-	latestVersion := 50
-	numHeightsPruned := 20
-	prunePeriod := 5
-
-	wg := sync.WaitGroup{}
-	triggerStartCh := make(chan bool)
-
-	// start a goroutine that prunes the database
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-		for i := 10; i <= latestVersion-numHeightsPruned; i += prunePeriod {
-			s.Require().NoError(db.Prune(int64(i)))
-		}
-	}()
-
-	// start a goroutine that iterates over the database
-	wg.Add(1)
-	go func() {
-		<-triggerStartCh
-		defer wg.Done()
-		// iterator without an end key over multiple versions
-		for v := int64(latestVersion - numHeightsPruned + 1); v < int64(latestVersion); v++ {
-			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
-			s.Require().NoError(err)
-
-			defer itr.Close()
-
-			var i, count int
-			for ; itr.Valid(); itr.Next() {
-				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
-
-				i++
-				count++
-			}
-			s.Require().Equal(10, count)
-			s.Require().NoError(itr.Error())
-
-			// seek past domain, which should make the iterator invalid and produce an error
-			itr.Next()
-			s.Require().False(itr.Valid())
-		}
-	}()
-
-	// wait for the goroutines
-	close(triggerStartCh)
-	wg.Wait()
-
-	// Ensure all keys are no longer present up to latestVersion - 20 and
-	// all keys are present after
-	for v := int64(1); v <= int64(latestVersion); v++ {
-		for i := 0; i < 10; i++ {
-			key := fmt.Sprintf("key%03d", i)
-			val := fmt.Sprintf("val%03d-%03d", i, v)
-
-			bz, err := db.Get(storeKey1, v, []byte(key))
-			s.Require().NoError(err)
-			if v <= int64(latestVersion-numHeightsPruned) {
-				s.Require().Nil(bz)
-			} else {
-				s.Require().Equal([]byte(val), bz)
-			}
-		}
-	}
-}
-
-func (s *StorageTestSuite) TestDatabaseParallelIterationVersions() {
-	db, err := s.NewDB(s.T().TempDir())
-	s.Require().NoError(err)
-	defer db.Close()
-
-	s.Require().NoError(FillData(db, 10, 100))
-
-	wg := sync.WaitGroup{}
-	triggerStartCh := make(chan bool)
-
-	latestVersion := 100
-	kvCount := 10
-
-	// start multiple goroutines that iterate over different version of the database
-	for v := 1; v < latestVersion; v++ {
-		wg.Add(1)
-		go func(v int) {
-			<-triggerStartCh
-			defer wg.Done()
-
-			itr, err := db.Iterator(storeKey1, int64(v), []byte("key000"), nil)
-			s.Require().NoError(err)
-
-			defer itr.Close()
-
-			var i, count int
-			for ; itr.Valid(); itr.Next() {
-				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
-
-				i++
-				count++
-			}
-			s.Require().Equal(kvCount, count)
-			s.Require().NoError(itr.Error())
-
-			// seek past domain, which should make the iterator invalid and produce an error
-			itr.Next()
-			s.Require().False(itr.Valid())
-
-		}(v)
-	}
-
-	// wait for the goroutines
-	close(triggerStartCh)
-	wg.Wait()
-}
+// func (s *StorageTestSuite) TestDatabaseIteratorMultiVersion() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 10, 50))
+
+// 	// for versions 50-100, only update even keys
+// 	for v := int64(51); v <= 100; v++ {
+// 		keys := [][]byte{}
+// 		vals := [][]byte{}
+// 		for i := 0; i < 10; i++ {
+// 			if i%2 == 0 {
+// 				keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
+// 				vals = append(vals, []byte(fmt.Sprintf("val%03d-%03d", i, v)))
+// 			}
+// 		}
+// 		s.Require().NoError(DBApplyChangeset(db, v, storeKey1, keys, vals))
+// 	}
+
+// 	itr, err := db.Iterator(storeKey1, 69, []byte("key000"), nil)
+// 	s.Require().NoError(err)
+
+// 	defer itr.Close()
+
+// 	// All keys should be present; All odd keys should have a value that reflects
+// 	// version 49, and all even keys should have a value that reflects the desired
+// 	// version, 69.
+// 	var i, count int
+// 	for ; itr.Valid(); itr.Next() {
+// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+
+// 		if i%2 == 0 {
+// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 69)), itr.Value())
+// 		} else {
+// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
+// 		}
+
+// 		i = (i + 1) % 10
+// 		count++
+// 	}
+// 	s.Require().Equal(10, count)
+// 	s.Require().NoError(itr.Error())
+// }
+
+// func (s *StorageTestSuite) TestDatabaseIteratorNoDomain() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 10, 50))
+
+// 	// create an iterator over the entire domain
+// 	itr, err := db.Iterator(storeKey1, 50, nil, nil)
+// 	s.Require().NoError(err)
+
+// 	defer itr.Close()
+
+// 	var i, count int
+// 	for ; itr.Valid(); itr.Next() {
+// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+// 		s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
+
+// 		i++
+// 		count++
+// 	}
+// 	s.Require().Equal(10, count)
+// 	s.Require().NoError(itr.Error())
+// }
+
+// func (s *StorageTestSuite) TestDatabasePrune() {
+// 	if slices.Contains(s.SkipTests, s.T().Name()) {
+// 		s.T().SkipNow()
+// 	}
+
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 10, 50))
+
+// 	// prune the first 25 versions
+// 	s.Require().NoError(db.Prune(25))
+
+// 	latestVersion, err := db.GetLatestVersion()
+// 	s.Require().NoError(err)
+// 	s.Require().Equal(int64(50), latestVersion)
+
+// 	// Ensure all keys are no longer present up to and including version 25 and
+// 	// all keys are present after version 25.
+// 	for v := int64(1); v <= 50; v++ {
+// 		for i := 0; i < 10; i++ {
+// 			key := fmt.Sprintf("key%03d", i)
+// 			val := fmt.Sprintf("val%03d-%03d", i, v)
+
+// 			bz, err := db.Get(storeKey1, v, []byte(key))
+// 			s.Require().NoError(err)
+// 			if v <= 25 {
+// 				s.Require().Nil(bz)
+// 			} else {
+// 				s.Require().Equal([]byte(val), bz)
+// 			}
+// 		}
+// 	}
+
+// 	itr, err := db.Iterator(storeKey1, 25, []byte("key000"), nil)
+// 	s.Require().NoError(err)
+// 	s.Require().False(itr.Valid())
+
+// 	// prune the latest version which should prune the entire dataset
+// 	s.Require().NoError(db.Prune(50))
+
+// 	for v := int64(1); v <= 50; v++ {
+// 		for i := 0; i < 10; i++ {
+// 			key := fmt.Sprintf("key%03d", i)
+
+// 			bz, err := db.Get(storeKey1, v, []byte(key))
+// 			s.Require().NoError(err)
+// 			s.Require().Nil(bz)
+// 		}
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestDatabasePruneKeepRecent() {
+// 	if slices.Contains(s.SkipTests, s.T().Name()) {
+// 		s.T().SkipNow()
+// 	}
+
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	key := []byte("key000")
+
+// 	// write a key at three different versions 1, 100 and 200
+// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{[]byte("value001")}))
+// 	s.Require().NoError(DBApplyChangeset(db, 100, storeKey1, [][]byte{key}, [][]byte{[]byte("value002")}))
+// 	s.Require().NoError(DBApplyChangeset(db, 200, storeKey1, [][]byte{key}, [][]byte{[]byte("value003")}))
+
+// 	// prune version 50
+// 	s.Require().NoError(db.Prune(50))
+
+// 	// ensure queries for versions 50 and older return nil
+// 	bz, err := db.Get(storeKey1, 49, key)
+// 	s.Require().Nil(err)
+// 	s.Require().Nil(bz)
+
+// 	itr, err := db.Iterator(storeKey1, 49, nil, nil)
+// 	s.Require().NoError(err)
+// 	s.Require().False(itr.Valid())
+
+// 	defer itr.Close()
+
+// 	// ensure the value previously at version 1 is still there for queries greater than 50
+// 	bz, err = db.Get(storeKey1, 51, key)
+// 	s.Require().NoError(err)
+// 	s.Require().Equal([]byte("value001"), bz)
+
+// 	// ensure the correct value at a greater height
+// 	bz, err = db.Get(storeKey1, 200, key)
+// 	s.Require().NoError(err)
+// 	s.Require().Equal([]byte("value003"), bz)
+
+// 	// prune latest height and ensure we have the previous version when querying above it
+// 	s.Require().NoError(db.Prune(200))
+
+// 	bz, err = db.Get(storeKey1, 201, key)
+// 	s.Require().NoError(err)
+// 	s.Require().Equal([]byte("value003"), bz)
+// }
+
+// func (s *StorageTestSuite) TestDatabaseReverseIterator() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 100, 1))
+
+// 	// reverse iterator without an end key
+// 	iter, err := db.ReverseIterator(storeKey1, 1, []byte("key000"), nil)
+// 	s.Require().NoError(err)
+
+// 	defer iter.Close()
+
+// 	i, count := 99, 0
+// 	for ; iter.Valid(); iter.Next() {
+// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter.Key())
+// 		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter.Value())
+
+// 		i--
+// 		count++
+// 	}
+// 	s.Require().Equal(100, count)
+// 	s.Require().NoError(iter.Error())
+
+// 	// seek past domain, which should make the iterator invalid and produce an error
+// 	iter.Next()
+// 	s.Require().False(iter.Valid())
+
+// 	// reverse iterator with with a start and end domain
+// 	iter2, err := db.ReverseIterator(storeKey1, 1, []byte("key010"), []byte("key019"))
+// 	s.Require().NoError(err)
+
+// 	defer iter2.Close()
+
+// 	i, count = 18, 0
+// 	for ; iter2.Valid(); iter2.Next() {
+// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter2.Key())
+// 		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter2.Value())
+
+// 		i--
+// 		count++
+// 	}
+// 	s.Require().Equal(9, count)
+// 	s.Require().NoError(iter2.Error())
+
+// 	// seek past domain, which should make the iterator invalid and produce an error
+// 	iter2.Next()
+// 	s.Require().False(iter2.Valid())
+
+// 	// start must be <= end
+// 	iter3, err := db.ReverseIterator(storeKey1, 1, []byte("key020"), []byte("key019"))
+// 	s.Require().Error(err)
+// 	s.Require().Nil(iter3)
+// }
+
+// func (s *StorageTestSuite) TestParallelWrites() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	latestVersion := 10
+// 	kvCount := 100
+
+// 	wg := sync.WaitGroup{}
+// 	triggerStartCh := make(chan bool)
+
+// 	// start 10 goroutines that write to the database
+// 	for i := 0; i < latestVersion; i++ {
+// 		wg.Add(1)
+// 		go func(i int) {
+// 			<-triggerStartCh
+// 			defer wg.Done()
+// 			keys := [][]byte{}
+// 			vals := [][]byte{}
+// 			for j := 0; j < kvCount; j++ {
+// 				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
+// 				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
+// 			}
+// 			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
+// 		}(i)
+
+// 	}
+
+// 	// start the goroutines
+// 	close(triggerStartCh)
+// 	wg.Wait()
+
+// 	// check that all the data is there
+// 	for i := 0; i < latestVersion; i++ {
+// 		for j := 0; j < kvCount; j++ {
+// 			version := int64(i + 1)
+// 			key := fmt.Sprintf("key-%d-%03d", i, j)
+// 			val := fmt.Sprintf("val-%d-%03d", i, j)
+
+// 			v, err := db.Get(storeKey1, version, []byte(key))
+// 			s.Require().NoError(err)
+// 			s.Require().Equal([]byte(val), v)
+// 		}
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestParallelWriteAndPruning() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	latestVersion := 100
+// 	kvCount := 100
+// 	prunePeriod := 5
+
+// 	wg := sync.WaitGroup{}
+// 	triggerStartCh := make(chan bool)
+
+// 	// start a goroutine that write to the database
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+// 		for i := 0; i < latestVersion; i++ {
+// 			keys := [][]byte{}
+// 			vals := [][]byte{}
+// 			for j := 0; j < kvCount; j++ {
+// 				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
+// 				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
+// 			}
+// 			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
+// 		}
+// 	}()
+
+// 	// start a goroutine that prunes the database
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+// 		for i := 10; i < latestVersion; i += prunePeriod {
+// 			for {
+// 				v, err := db.GetLatestVersion()
+// 				s.Require().NoError(err)
+// 				if v > int64(i) {
+// 					s.Require().NoError(db.Prune(v - 1))
+// 					break
+// 				}
+// 			}
+// 		}
+// 	}()
+
+// 	// wait for the goroutines
+// 	close(triggerStartCh)
+// 	wg.Wait()
+
+// 	// check if the data is pruned
+// 	version := int64(latestVersion - prunePeriod)
+// 	val, err := db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
+// 	s.Require().Nil(err)
+// 	s.Require().Nil(val)
+
+// 	version = int64(latestVersion)
+// 	val, err = db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
+// 	s.Require().NoError(err)
+// 	s.Require().Equal([]byte(fmt.Sprintf("val-%d-%03d", version-1, 0)), val)
+// }
+
+// func (s *StorageTestSuite) TestDatabaseParallelDeleteIteration() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 100, 100))
+
+// 	wg := sync.WaitGroup{}
+// 	triggerStartCh := make(chan bool)
+
+// 	latestVersion := 100
+// 	kvCount := 100
+
+// 	// start a goroutine that deletes from the database at latest Version
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+
+// 		for j := 0; j < kvCount; j++ {
+// 			if j%10 == 0 {
+// 				key := []byte(fmt.Sprintf("key%03d", j))
+// 				s.Require().NoError(DBApplyChangeset(db, int64(latestVersion), storeKey1, [][]byte{key}, [][]byte{nil}))
+// 			}
+// 		}
+// 	}()
+
+// 	// start a goroutine that iterates over the database
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+// 		// iterator without an end key over multiple versions
+// 		for v := int64(1); v < 5; v++ {
+// 			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
+// 			s.Require().NoError(err)
+
+// 			defer itr.Close()
+
+// 			var i, count int
+// 			for ; itr.Valid(); itr.Next() {
+// 				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+// 				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
+
+// 				i++
+// 				count++
+// 			}
+// 			s.Require().Equal(100, count)
+// 			s.Require().NoError(itr.Error())
+
+// 			// seek past domain, which should make the iterator invalid and produce an error
+// 			itr.Next()
+// 			s.Require().False(itr.Valid())
+// 		}
+// 	}()
+
+// 	// wait for the goroutines
+// 	close(triggerStartCh)
+// 	wg.Wait()
+
+// 	// Verify deletes
+// 	for j := 0; j < 100; j++ {
+// 		ok, err := db.Has(storeKey1, int64(latestVersion), []byte(fmt.Sprintf("key%03d", j)))
+// 		s.Require().NoError(err)
+
+// 		if j%10 == 0 {
+// 			s.Require().False(ok)
+// 		} else {
+// 			s.Require().True(ok)
+// 		}
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestDatabaseParallelWriteDelete() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 100, 1))
+
+// 	wg := sync.WaitGroup{}
+// 	triggerStartCh := make(chan bool)
+
+// 	latestVersion := int64(2)
+
+// 	// start a goroutine that writes to the database at latestVersion
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+
+// 		cs := &iavl.ChangeSet{}
+// 		cs.Pairs = []*iavl.KVPair{}
+
+// 		for i := 0; i < 50; i++ {
+// 			// Apply changeset for each key separately
+// 			key := []byte(fmt.Sprintf("key%03d", i))
+// 			val := []byte(fmt.Sprintf("val%03d", i))
+// 			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{val}))
+// 		}
+// 	}()
+
+// 	// start a goroutine that deletes from the database
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+
+// 		cs := &iavl.ChangeSet{}
+// 		cs.Pairs = []*iavl.KVPair{}
+
+// 		for i := 50; i < 100; i++ {
+// 			// Apply changeset for each key separately
+// 			key := []byte(fmt.Sprintf("key%03d", i))
+// 			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{nil}))
+// 		}
+// 	}()
+
+// 	// wait for the goroutines
+// 	close(triggerStartCh)
+// 	wg.Wait()
+
+// 	// Verify writes and deletes on latest version
+// 	for j := 0; j < 100; j++ {
+// 		ok, err := db.Has(storeKey1, latestVersion, []byte(fmt.Sprintf("key%03d", j)))
+// 		s.Require().NoError(err)
+
+// 		if j >= 50 {
+// 			s.Require().False(ok)
+// 		} else {
+// 			s.Require().True(ok)
+// 		}
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestParallelIterationAndPruning() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 10, 50))
+
+// 	latestVersion := 50
+// 	numHeightsPruned := 20
+// 	prunePeriod := 5
+
+// 	wg := sync.WaitGroup{}
+// 	triggerStartCh := make(chan bool)
+
+// 	// start a goroutine that prunes the database
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+// 		for i := 10; i <= latestVersion-numHeightsPruned; i += prunePeriod {
+// 			s.Require().NoError(db.Prune(int64(i)))
+// 		}
+// 	}()
+
+// 	// start a goroutine that iterates over the database
+// 	wg.Add(1)
+// 	go func() {
+// 		<-triggerStartCh
+// 		defer wg.Done()
+// 		// iterator without an end key over multiple versions
+// 		for v := int64(latestVersion - numHeightsPruned + 1); v < int64(latestVersion); v++ {
+// 			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
+// 			s.Require().NoError(err)
+
+// 			defer itr.Close()
+
+// 			var i, count int
+// 			for ; itr.Valid(); itr.Next() {
+// 				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+// 				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
+
+// 				i++
+// 				count++
+// 			}
+// 			s.Require().Equal(10, count)
+// 			s.Require().NoError(itr.Error())
+
+// 			// seek past domain, which should make the iterator invalid and produce an error
+// 			itr.Next()
+// 			s.Require().False(itr.Valid())
+// 		}
+// 	}()
+
+// 	// wait for the goroutines
+// 	close(triggerStartCh)
+// 	wg.Wait()
+
+// 	// Ensure all keys are no longer present up to latestVersion - 20 and
+// 	// all keys are present after
+// 	for v := int64(1); v <= int64(latestVersion); v++ {
+// 		for i := 0; i < 10; i++ {
+// 			key := fmt.Sprintf("key%03d", i)
+// 			val := fmt.Sprintf("val%03d-%03d", i, v)
+
+// 			bz, err := db.Get(storeKey1, v, []byte(key))
+// 			s.Require().NoError(err)
+// 			if v <= int64(latestVersion-numHeightsPruned) {
+// 				s.Require().Nil(bz)
+// 			} else {
+// 				s.Require().Equal([]byte(val), bz)
+// 			}
+// 		}
+// 	}
+// }
+
+// func (s *StorageTestSuite) TestDatabaseParallelIterationVersions() {
+// 	db, err := s.NewDB(s.T().TempDir())
+// 	s.Require().NoError(err)
+// 	defer db.Close()
+
+// 	s.Require().NoError(FillData(db, 10, 100))
+
+// 	wg := sync.WaitGroup{}
+// 	triggerStartCh := make(chan bool)
+
+// 	latestVersion := 100
+// 	kvCount := 10
+
+// 	// start multiple goroutines that iterate over different version of the database
+// 	for v := 1; v < latestVersion; v++ {
+// 		wg.Add(1)
+// 		go func(v int) {
+// 			<-triggerStartCh
+// 			defer wg.Done()
+
+// 			itr, err := db.Iterator(storeKey1, int64(v), []byte("key000"), nil)
+// 			s.Require().NoError(err)
+
+// 			defer itr.Close()
+
+// 			var i, count int
+// 			for ; itr.Valid(); itr.Next() {
+// 				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+// 				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
+
+// 				i++
+// 				count++
+// 			}
+// 			s.Require().Equal(kvCount, count)
+// 			s.Require().NoError(itr.Error())
+
+// 			// seek past domain, which should make the iterator invalid and produce an error
+// 			itr.Next()
+// 			s.Require().False(itr.Valid())
+
+// 		}(v)
+// 	}
+
+// 	// wait for the goroutines
+// 	close(triggerStartCh)
+// 	wg.Wait()
+// }

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -388,16 +388,12 @@ func (s *StorageTestSuite) TestDatabaseIteratorLooping() {
 
 	defer itr.Close()
 
-	// All keys should be present; All odd keys should have a value that reflects
-	// version 49, and all even keys should have a value that reflects the desired
-	// version, 69.
 	count := 0
 	for ; itr.Valid(); itr.Next() {
-		fmt.Printf("itr key %+X\n", itr.Key())
 		count++
 	}
 
-	s.Require().Equal(1, count)
+	s.Require().Equal(3, count)
 }
 
 func (s *StorageTestSuite) TestDatabaseIteratorNoDomain() {

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -380,6 +380,8 @@ func (s *StorageTestSuite) TestDatabaseIteratorLooping() {
 	// Both below are greater
 	s.Require().NoError(DBApplyChangeset(db, 58833605, storeKey1, [][]byte{[]byte("keyC")}, [][]byte{[]byte("value004")}))
 	s.Require().NoError(DBApplyChangeset(db, 58833606, storeKey1, [][]byte{[]byte("keyD")}, [][]byte{[]byte("value006")}))
+	s.Require().NoError(DBApplyChangeset(db, 58827507, storeKey1, [][]byte{[]byte("keyE")}, [][]byte{[]byte("value006")}))
+	s.Require().NoError(DBApplyChangeset(db, 58827508, storeKey1, [][]byte{[]byte("keyF")}, [][]byte{[]byte("value007")}))
 
 	itr, err := db.Iterator(storeKey1, 58831525, []byte("keyA"), nil)
 	s.Require().NoError(err)
@@ -391,6 +393,7 @@ func (s *StorageTestSuite) TestDatabaseIteratorLooping() {
 	// version, 69.
 	count := 0
 	for ; itr.Valid(); itr.Next() {
+		fmt.Printf("itr key %+X\n", itr.Key())
 		count++
 	}
 

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -2,9 +2,13 @@ package sstest
 
 import (
 	"fmt"
+	"sync"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/cosmos/iavl"
 	"github.com/sei-protocol/sei-db/ss/types"
 )
 
@@ -21,306 +25,352 @@ type StorageTestSuite struct {
 	SkipTests      []string
 }
 
-// func (s *StorageTestSuite) TestDatabaseClose() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	s.Require().NoError(db.Close())
+func (s *StorageTestSuite) TestDatabaseClose() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	s.Require().NoError(db.Close())
 
-// 	// close should not be idempotent
-// 	s.Require().Panics(func() { _ = db.Close() })
-// }
+	// close should not be idempotent
+	s.Require().Panics(func() { _ = db.Close() })
+}
 
-// func (s *StorageTestSuite) TestDatabaseLatestVersion() {
-// 	tempDir := s.T().TempDir()
-// 	db, err := s.NewDB(tempDir)
-// 	s.Require().NoError(err)
+func (s *StorageTestSuite) TestDatabaseLatestVersion() {
+	tempDir := s.T().TempDir()
+	db, err := s.NewDB(tempDir)
+	s.Require().NoError(err)
 
-// 	lv, err := db.GetLatestVersion()
-// 	s.Require().NoError(err)
-// 	s.Require().Zero(lv)
+	lv, err := db.GetLatestVersion()
+	s.Require().NoError(err)
+	s.Require().Zero(lv)
 
-// 	i := int64(1)
-// 	for ; i <= 1001; i++ {
-// 		err = db.SetLatestVersion(i)
-// 		s.Require().NoError(err)
+	i := int64(1)
+	for ; i <= 1001; i++ {
+		err = db.SetLatestVersion(i)
+		s.Require().NoError(err)
 
-// 		lv, err = db.GetLatestVersion()
-// 		s.Require().NoError(err)
-// 		s.Require().Equal(i, lv)
-// 	}
+		lv, err = db.GetLatestVersion()
+		s.Require().NoError(err)
+		s.Require().Equal(i, lv)
+	}
 
-// 	// Test even after closing and reopening, the latest version is maintained
-// 	err = db.Close()
-// 	s.Require().NoError(err)
+	// Test even after closing and reopening, the latest version is maintained
+	err = db.Close()
+	s.Require().NoError(err)
 
-// 	newDB, err := s.NewDB(tempDir)
-// 	s.Require().NoError(err)
-// 	defer newDB.Close()
+	newDB, err := s.NewDB(tempDir)
+	s.Require().NoError(err)
+	defer newDB.Close()
 
-// 	lv, err = newDB.GetLatestVersion()
-// 	s.Require().NoError(err)
-// 	s.Require().Equal(i-1, lv)
+	lv, err = newDB.GetLatestVersion()
+	s.Require().NoError(err)
+	s.Require().Equal(i-1, lv)
 
-// }
+}
 
-// func (s *StorageTestSuite) TestDatabaseVersionedKeys() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseVersionedKeys() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	s.Require().NoError(FillData(db, 1, 100))
+	s.Require().NoError(FillData(db, 1, 100))
 
-// 	for i := int64(1); i <= 100; i++ {
-// 		bz, err := db.Get(storeKey1, i, []byte("key000"))
-// 		s.Require().NoError(err)
-// 		s.Require().Equal(fmt.Sprintf("val000-%03d", i), string(bz))
-// 	}
-// }
+	for i := int64(1); i <= 100; i++ {
+		bz, err := db.Get(storeKey1, i, []byte("key000"))
+		s.Require().NoError(err)
+		s.Require().Equal(fmt.Sprintf("val000-%03d", i), string(bz))
+	}
+}
 
-// func (s *StorageTestSuite) TestDatabaseGetVersionedKey() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseGetVersionedKey() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	key := []byte("key")
-// 	val := []byte("value001")
+	key := []byte("key")
+	val := []byte("value001")
 
-// 	// store a key at version 1
-// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{val}))
+	// store a key at version 1
+	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{val}))
 
-// 	// assume chain progresses to version 10 w/o any changes to key
-// 	bz, err := db.Get(storeKey1, 10, key)
-// 	s.Require().NoError(err)
-// 	s.Require().Equal(val, bz)
+	// assume chain progresses to version 10 w/o any changes to key
+	bz, err := db.Get(storeKey1, 10, key)
+	s.Require().NoError(err)
+	s.Require().Equal(val, bz)
 
-// 	ok, err := db.Has(storeKey1, 10, key)
-// 	s.Require().NoError(err)
-// 	s.Require().True(ok)
+	ok, err := db.Has(storeKey1, 10, key)
+	s.Require().NoError(err)
+	s.Require().True(ok)
 
-// 	// chain progresses to version 11 with an update to key
-// 	newVal := []byte("value011")
-// 	s.Require().NoError(DBApplyChangeset(db, 11, storeKey1, [][]byte{key}, [][]byte{newVal}))
+	// chain progresses to version 11 with an update to key
+	newVal := []byte("value011")
+	s.Require().NoError(DBApplyChangeset(db, 11, storeKey1, [][]byte{key}, [][]byte{newVal}))
 
-// 	bz, err = db.Get(storeKey1, 10, key)
-// 	s.Require().NoError(err)
-// 	s.Require().Equal(val, bz)
+	bz, err = db.Get(storeKey1, 10, key)
+	s.Require().NoError(err)
+	s.Require().Equal(val, bz)
 
-// 	ok, err = db.Has(storeKey1, 10, key)
-// 	s.Require().NoError(err)
-// 	s.Require().True(ok)
+	ok, err = db.Has(storeKey1, 10, key)
+	s.Require().NoError(err)
+	s.Require().True(ok)
 
-// 	for i := int64(11); i <= 14; i++ {
-// 		bz, err = db.Get(storeKey1, i, key)
-// 		s.Require().NoError(err)
-// 		s.Require().Equal(newVal, bz)
+	for i := int64(11); i <= 14; i++ {
+		bz, err = db.Get(storeKey1, i, key)
+		s.Require().NoError(err)
+		s.Require().Equal(newVal, bz)
 
-// 		ok, err = db.Has(storeKey1, i, key)
-// 		s.Require().NoError(err)
-// 		s.Require().True(ok)
-// 	}
+		ok, err = db.Has(storeKey1, i, key)
+		s.Require().NoError(err)
+		s.Require().True(ok)
+	}
 
-// 	// chain progresses to version 15 with a delete to key
-// 	s.Require().NoError(DBApplyChangeset(db, 15, storeKey1, [][]byte{key}, [][]byte{nil}))
+	// chain progresses to version 15 with a delete to key
+	s.Require().NoError(DBApplyChangeset(db, 15, storeKey1, [][]byte{key}, [][]byte{nil}))
 
-// 	// all queries up to version 14 should return the latest value
-// 	for i := int64(1); i <= 14; i++ {
-// 		bz, err = db.Get(storeKey1, i, key)
-// 		s.Require().NoError(err)
-// 		s.Require().NotNil(bz)
+	// all queries up to version 14 should return the latest value
+	for i := int64(1); i <= 14; i++ {
+		bz, err = db.Get(storeKey1, i, key)
+		s.Require().NoError(err)
+		s.Require().NotNil(bz)
 
-// 		ok, err = db.Has(storeKey1, i, key)
-// 		s.Require().NoError(err)
-// 		s.Require().True(ok)
-// 	}
+		ok, err = db.Has(storeKey1, i, key)
+		s.Require().NoError(err)
+		s.Require().True(ok)
+	}
 
-// 	// all queries after version 15 should return nil
-// 	for i := int64(15); i <= 17; i++ {
-// 		bz, err = db.Get(storeKey1, i, key)
-// 		s.Require().NoError(err)
-// 		s.Require().Nil(bz)
+	// all queries after version 15 should return nil
+	for i := int64(15); i <= 17; i++ {
+		bz, err = db.Get(storeKey1, i, key)
+		s.Require().NoError(err)
+		s.Require().Nil(bz)
 
-// 		ok, err = db.Has(storeKey1, i, key)
-// 		s.Require().NoError(err)
-// 		s.Require().False(ok)
-// 	}
-// }
+		ok, err = db.Has(storeKey1, i, key)
+		s.Require().NoError(err)
+		s.Require().False(ok)
+	}
+}
 
-// func (s *StorageTestSuite) TestDatabaseApplyChangeset() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseApplyChangeset() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	s.Require().NoError(FillData(db, 100, 1))
+	s.Require().NoError(FillData(db, 100, 1))
 
-// 	cs := &iavl.ChangeSet{}
-// 	cs.Pairs = []*iavl.KVPair{}
+	cs := &iavl.ChangeSet{}
+	cs.Pairs = []*iavl.KVPair{}
 
-// 	// Deletes
-// 	keys := [][]byte{}
-// 	vals := [][]byte{}
-// 	for i := 0; i < 100; i++ {
-// 		if i%10 == 0 {
-// 			keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
-// 			vals = append(vals, nil)
-// 		}
-// 	}
-// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, keys, vals))
+	// Deletes
+	keys := [][]byte{}
+	vals := [][]byte{}
+	for i := 0; i < 100; i++ {
+		if i%10 == 0 {
+			keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
+			vals = append(vals, nil)
+		}
+	}
+	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, keys, vals))
 
-// 	lv, err := db.GetLatestVersion()
-// 	s.Require().NoError(err)
-// 	s.Require().Equal(int64(1), lv)
+	lv, err := db.GetLatestVersion()
+	s.Require().NoError(err)
+	s.Require().Equal(int64(1), lv)
 
-// 	for i := 0; i < 100; i++ {
-// 		ok, err := db.Has(storeKey1, 1, []byte(fmt.Sprintf("key%03d", i)))
-// 		s.Require().NoError(err)
+	for i := 0; i < 100; i++ {
+		ok, err := db.Has(storeKey1, 1, []byte(fmt.Sprintf("key%03d", i)))
+		s.Require().NoError(err)
 
-// 		if i%10 == 0 {
-// 			s.Require().False(ok)
-// 		} else {
-// 			s.Require().True(ok)
-// 		}
-// 	}
-// }
+		if i%10 == 0 {
+			s.Require().False(ok)
+		} else {
+			s.Require().True(ok)
+		}
+	}
+}
 
-// func (s *StorageTestSuite) TestDatabaseIteratorEmptyDomain() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseIteratorEmptyDomain() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	iter, err := db.Iterator(storeKey1, 1, []byte{}, []byte{})
-// 	s.Require().Error(err)
-// 	s.Require().Nil(iter)
-// }
+	iter, err := db.Iterator(storeKey1, 1, []byte{}, []byte{})
+	s.Require().Error(err)
+	s.Require().Nil(iter)
+}
 
-// func (s *StorageTestSuite) TestDatabaseIteratorClose() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseIteratorClose() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	iter, err := db.Iterator(storeKey1, 1, []byte("key000"), nil)
-// 	s.Require().NoError(err)
-// 	iter.Close()
+	iter, err := db.Iterator(storeKey1, 1, []byte("key000"), nil)
+	s.Require().NoError(err)
+	iter.Close()
 
-// 	s.Require().False(iter.Valid())
-// 	s.Require().Panics(func() { iter.Close() })
-// }
+	s.Require().False(iter.Valid())
+	s.Require().Panics(func() { iter.Close() })
+}
 
-// func (s *StorageTestSuite) TestDatabaseIteratorDomain() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseIteratorDomain() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	testCases := map[string]struct {
-// 		start, end []byte
-// 	}{
-// 		"start without end domain": {
-// 			start: []byte("key010"),
-// 		},
-// 		"start and end domain": {
-// 			start: []byte("key010"),
-// 			end:   []byte("key020"),
-// 		},
-// 	}
+	testCases := map[string]struct {
+		start, end []byte
+	}{
+		"start without end domain": {
+			start: []byte("key010"),
+		},
+		"start and end domain": {
+			start: []byte("key010"),
+			end:   []byte("key020"),
+		},
+	}
 
-// 	for name, tc := range testCases {
-// 		s.Run(name, func() {
-// 			iter, err := db.Iterator(storeKey1, 1, tc.start, tc.end)
-// 			s.Require().NoError(err)
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			iter, err := db.Iterator(storeKey1, 1, tc.start, tc.end)
+			s.Require().NoError(err)
 
-// 			defer iter.Close()
+			defer iter.Close()
 
-// 			start, end := iter.Domain()
-// 			s.Require().Equal(tc.start, start)
-// 			s.Require().Equal(tc.end, end)
-// 		})
-// 	}
-// }
+			start, end := iter.Domain()
+			s.Require().Equal(tc.start, start)
+			s.Require().Equal(tc.end, end)
+		})
+	}
+}
 
-// func (s *StorageTestSuite) TestDatabaseIterator() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseIterator() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	s.Require().NoError(FillData(db, 100, 1))
+	s.Require().NoError(FillData(db, 100, 1))
 
-// 	// iterator without an end key over multiple versions
-// 	for v := int64(1); v < 5; v++ {
-// 		itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
-// 		s.Require().NoError(err)
+	// iterator without an end key over multiple versions
+	for v := int64(1); v < 5; v++ {
+		itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
+		s.Require().NoError(err)
 
-// 		defer itr.Close()
+		defer itr.Close()
 
-// 		var i, count int
-// 		for ; itr.Valid(); itr.Next() {
-// 			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr.Value())
+		var i, count int
+		for ; itr.Valid(); itr.Next() {
+			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr.Value())
 
-// 			i++
-// 			count++
-// 		}
-// 		s.Require().Equal(100, count)
-// 		s.Require().NoError(itr.Error())
+			i++
+			count++
+		}
+		s.Require().Equal(100, count)
+		s.Require().NoError(itr.Error())
 
-// 		// seek past domain, which should make the iterator invalid and produce an error
-// 		itr.Next()
-// 		s.Require().False(itr.Valid())
-// 	}
+		// seek past domain, which should make the iterator invalid and produce an error
+		itr.Next()
+		s.Require().False(itr.Valid())
+	}
 
-// 	// iterator with with a start and end domain over multiple versions
-// 	for v := int64(1); v < 5; v++ {
-// 		itr2, err := db.Iterator(storeKey1, v, []byte("key010"), []byte("key019"))
-// 		s.Require().NoError(err)
+	// iterator with with a start and end domain over multiple versions
+	for v := int64(1); v < 5; v++ {
+		itr2, err := db.Iterator(storeKey1, v, []byte("key010"), []byte("key019"))
+		s.Require().NoError(err)
 
-// 		defer itr2.Close()
+		defer itr2.Close()
 
-// 		i, count := 10, 0
-// 		for ; itr2.Valid(); itr2.Next() {
-// 			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr2.Key())
-// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr2.Value())
+		i, count := 10, 0
+		for ; itr2.Valid(); itr2.Next() {
+			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr2.Key())
+			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 1)), itr2.Value())
 
-// 			i++
-// 			count++
-// 		}
-// 		s.Require().Equal(9, count)
-// 		s.Require().NoError(itr2.Error())
+			i++
+			count++
+		}
+		s.Require().Equal(9, count)
+		s.Require().NoError(itr2.Error())
 
-// 		// seek past domain, which should make the iterator invalid and produce an error
-// 		itr2.Next()
-// 		s.Require().False(itr2.Valid())
-// 	}
+		// seek past domain, which should make the iterator invalid and produce an error
+		itr2.Next()
+		s.Require().False(itr2.Valid())
+	}
 
-// 	// start must be <= end
-// 	iter3, err := db.Iterator(storeKey1, 1, []byte("key020"), []byte("key019"))
-// 	s.Require().Error(err)
-// 	s.Require().Nil(iter3)
-// }
+	// start must be <= end
+	iter3, err := db.Iterator(storeKey1, 1, []byte("key020"), []byte("key019"))
+	s.Require().Error(err)
+	s.Require().Nil(iter3)
+}
 
-// func (s *StorageTestSuite) TestDatabaseIteratorRangedDeletes() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
+func (s *StorageTestSuite) TestDatabaseIteratorRangedDeletes() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
 
-// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key001")}, [][]byte{[]byte("value001")}))
-// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value001")}))
-// 	s.Require().NoError(DBApplyChangeset(db, 5, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value002")}))
-// 	s.Require().NoError(DBApplyChangeset(db, 10, storeKey1, [][]byte{[]byte("key002")}, [][]byte{nil}))
+	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key001")}, [][]byte{[]byte("value001")}))
+	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value001")}))
+	s.Require().NoError(DBApplyChangeset(db, 5, storeKey1, [][]byte{[]byte("key002")}, [][]byte{[]byte("value002")}))
+	s.Require().NoError(DBApplyChangeset(db, 10, storeKey1, [][]byte{[]byte("key002")}, [][]byte{nil}))
 
-// 	itr, err := db.Iterator(storeKey1, 11, []byte("key001"), nil)
-// 	s.Require().NoError(err)
+	itr, err := db.Iterator(storeKey1, 11, []byte("key001"), nil)
+	s.Require().NoError(err)
 
-// 	defer itr.Close()
+	defer itr.Close()
 
-// 	// there should only be one valid key in the iterator -- key001
-// 	var count int
-// 	for ; itr.Valid(); itr.Next() {
-// 		s.Require().Equal([]byte("key001"), itr.Key())
-// 		count++
-// 	}
-// 	s.Require().Equal(1, count)
-// 	s.Require().NoError(itr.Error())
-// }
+	// there should only be one valid key in the iterator -- key001
+	var count int
+	for ; itr.Valid(); itr.Next() {
+		s.Require().Equal([]byte("key001"), itr.Key())
+		count++
+	}
+	s.Require().Equal(1, count)
+	s.Require().NoError(itr.Error())
+}
 
-func (s *StorageTestSuite) TestDatabaseIteratorBug() {
+func (s *StorageTestSuite) TestDatabaseIteratorMultiVersion() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 10, 50))
+
+	// for versions 50-100, only update even keys
+	for v := int64(51); v <= 100; v++ {
+		keys := [][]byte{}
+		vals := [][]byte{}
+		for i := 0; i < 10; i++ {
+			if i%2 == 0 {
+				keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
+				vals = append(vals, []byte(fmt.Sprintf("val%03d-%03d", i, v)))
+			}
+		}
+		s.Require().NoError(DBApplyChangeset(db, v, storeKey1, keys, vals))
+	}
+
+	itr, err := db.Iterator(storeKey1, 69, []byte("key000"), nil)
+	s.Require().NoError(err)
+
+	defer itr.Close()
+
+	// All keys should be present; All odd keys should have a value that reflects
+	// version 49, and all even keys should have a value that reflects the desired
+	// version, 69.
+	var i, count int
+	for ; itr.Valid(); itr.Next() {
+		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+
+		if i%2 == 0 {
+			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 69)), itr.Value())
+		} else {
+			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
+		}
+
+		i = (i + 1) % 10
+		count++
+	}
+	s.Require().Equal(10, count)
+	s.Require().NoError(itr.Error())
+}
+
+// Tests bug where iterator loops continuously
+func (s *StorageTestSuite) TestDatabaseIteratorLooping() {
 	db, err := s.NewDB(s.T().TempDir())
 	s.Require().NoError(err)
 	defer db.Close()
@@ -329,7 +379,7 @@ func (s *StorageTestSuite) TestDatabaseIteratorBug() {
 	s.Require().NoError(DBApplyChangeset(db, 58827506, storeKey1, [][]byte{[]byte("keyC")}, [][]byte{[]byte("value003")}))
 	// Both below are greater
 	s.Require().NoError(DBApplyChangeset(db, 58833605, storeKey1, [][]byte{[]byte("keyC")}, [][]byte{[]byte("value004")}))
-	s.Require().NoError(DBApplyChangeset(db, 58827507, storeKey1, [][]byte{[]byte("keyD")}, [][]byte{[]byte("value006")}))
+	s.Require().NoError(DBApplyChangeset(db, 58833606, storeKey1, [][]byte{[]byte("keyD")}, [][]byte{[]byte("value006")}))
 
 	itr, err := db.Iterator(storeKey1, 58831525, []byte("keyA"), nil)
 	s.Require().NoError(err)
@@ -339,599 +389,556 @@ func (s *StorageTestSuite) TestDatabaseIteratorBug() {
 	// All keys should be present; All odd keys should have a value that reflects
 	// version 49, and all even keys should have a value that reflects the desired
 	// version, 69.
+	count := 0
 	for ; itr.Valid(); itr.Next() {
-		fmt.Printf("itr key %s valid %+v\n", string(itr.Key()), itr.Valid())
+		count++
 	}
 
+	s.Require().Equal(1, count)
 }
 
-// func (s *StorageTestSuite) TestDatabaseIteratorMultiVersion() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 10, 50))
-
-// 	// for versions 50-100, only update even keys
-// 	for v := int64(51); v <= 100; v++ {
-// 		keys := [][]byte{}
-// 		vals := [][]byte{}
-// 		for i := 0; i < 10; i++ {
-// 			if i%2 == 0 {
-// 				keys = append(keys, []byte(fmt.Sprintf("key%03d", i)))
-// 				vals = append(vals, []byte(fmt.Sprintf("val%03d-%03d", i, v)))
-// 			}
-// 		}
-// 		s.Require().NoError(DBApplyChangeset(db, v, storeKey1, keys, vals))
-// 	}
-
-// 	itr, err := db.Iterator(storeKey1, 69, []byte("key000"), nil)
-// 	s.Require().NoError(err)
-
-// 	defer itr.Close()
-
-// 	// All keys should be present; All odd keys should have a value that reflects
-// 	// version 49, and all even keys should have a value that reflects the desired
-// 	// version, 69.
-// 	var i, count int
-// 	for ; itr.Valid(); itr.Next() {
-// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-
-// 		if i%2 == 0 {
-// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 69)), itr.Value())
-// 		} else {
-// 			s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
-// 		}
-
-// 		i = (i + 1) % 10
-// 		count++
-// 	}
-// 	s.Require().Equal(10, count)
-// 	s.Require().NoError(itr.Error())
-// }
-
-// func (s *StorageTestSuite) TestDatabaseIteratorNoDomain() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 10, 50))
-
-// 	// create an iterator over the entire domain
-// 	itr, err := db.Iterator(storeKey1, 50, nil, nil)
-// 	s.Require().NoError(err)
-
-// 	defer itr.Close()
-
-// 	var i, count int
-// 	for ; itr.Valid(); itr.Next() {
-// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-// 		s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
-
-// 		i++
-// 		count++
-// 	}
-// 	s.Require().Equal(10, count)
-// 	s.Require().NoError(itr.Error())
-// }
-
-// func (s *StorageTestSuite) TestDatabasePrune() {
-// 	if slices.Contains(s.SkipTests, s.T().Name()) {
-// 		s.T().SkipNow()
-// 	}
-
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 10, 50))
-
-// 	// prune the first 25 versions
-// 	s.Require().NoError(db.Prune(25))
-
-// 	latestVersion, err := db.GetLatestVersion()
-// 	s.Require().NoError(err)
-// 	s.Require().Equal(int64(50), latestVersion)
-
-// 	// Ensure all keys are no longer present up to and including version 25 and
-// 	// all keys are present after version 25.
-// 	for v := int64(1); v <= 50; v++ {
-// 		for i := 0; i < 10; i++ {
-// 			key := fmt.Sprintf("key%03d", i)
-// 			val := fmt.Sprintf("val%03d-%03d", i, v)
-
-// 			bz, err := db.Get(storeKey1, v, []byte(key))
-// 			s.Require().NoError(err)
-// 			if v <= 25 {
-// 				s.Require().Nil(bz)
-// 			} else {
-// 				s.Require().Equal([]byte(val), bz)
-// 			}
-// 		}
-// 	}
-
-// 	itr, err := db.Iterator(storeKey1, 25, []byte("key000"), nil)
-// 	s.Require().NoError(err)
-// 	s.Require().False(itr.Valid())
-
-// 	// prune the latest version which should prune the entire dataset
-// 	s.Require().NoError(db.Prune(50))
-
-// 	for v := int64(1); v <= 50; v++ {
-// 		for i := 0; i < 10; i++ {
-// 			key := fmt.Sprintf("key%03d", i)
-
-// 			bz, err := db.Get(storeKey1, v, []byte(key))
-// 			s.Require().NoError(err)
-// 			s.Require().Nil(bz)
-// 		}
-// 	}
-// }
-
-// func (s *StorageTestSuite) TestDatabasePruneKeepRecent() {
-// 	if slices.Contains(s.SkipTests, s.T().Name()) {
-// 		s.T().SkipNow()
-// 	}
-
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	key := []byte("key000")
-
-// 	// write a key at three different versions 1, 100 and 200
-// 	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{[]byte("value001")}))
-// 	s.Require().NoError(DBApplyChangeset(db, 100, storeKey1, [][]byte{key}, [][]byte{[]byte("value002")}))
-// 	s.Require().NoError(DBApplyChangeset(db, 200, storeKey1, [][]byte{key}, [][]byte{[]byte("value003")}))
-
-// 	// prune version 50
-// 	s.Require().NoError(db.Prune(50))
-
-// 	// ensure queries for versions 50 and older return nil
-// 	bz, err := db.Get(storeKey1, 49, key)
-// 	s.Require().Nil(err)
-// 	s.Require().Nil(bz)
-
-// 	itr, err := db.Iterator(storeKey1, 49, nil, nil)
-// 	s.Require().NoError(err)
-// 	s.Require().False(itr.Valid())
-
-// 	defer itr.Close()
-
-// 	// ensure the value previously at version 1 is still there for queries greater than 50
-// 	bz, err = db.Get(storeKey1, 51, key)
-// 	s.Require().NoError(err)
-// 	s.Require().Equal([]byte("value001"), bz)
-
-// 	// ensure the correct value at a greater height
-// 	bz, err = db.Get(storeKey1, 200, key)
-// 	s.Require().NoError(err)
-// 	s.Require().Equal([]byte("value003"), bz)
-
-// 	// prune latest height and ensure we have the previous version when querying above it
-// 	s.Require().NoError(db.Prune(200))
-
-// 	bz, err = db.Get(storeKey1, 201, key)
-// 	s.Require().NoError(err)
-// 	s.Require().Equal([]byte("value003"), bz)
-// }
-
-// func (s *StorageTestSuite) TestDatabaseReverseIterator() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 100, 1))
-
-// 	// reverse iterator without an end key
-// 	iter, err := db.ReverseIterator(storeKey1, 1, []byte("key000"), nil)
-// 	s.Require().NoError(err)
-
-// 	defer iter.Close()
-
-// 	i, count := 99, 0
-// 	for ; iter.Valid(); iter.Next() {
-// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter.Key())
-// 		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter.Value())
-
-// 		i--
-// 		count++
-// 	}
-// 	s.Require().Equal(100, count)
-// 	s.Require().NoError(iter.Error())
-
-// 	// seek past domain, which should make the iterator invalid and produce an error
-// 	iter.Next()
-// 	s.Require().False(iter.Valid())
-
-// 	// reverse iterator with with a start and end domain
-// 	iter2, err := db.ReverseIterator(storeKey1, 1, []byte("key010"), []byte("key019"))
-// 	s.Require().NoError(err)
-
-// 	defer iter2.Close()
-
-// 	i, count = 18, 0
-// 	for ; iter2.Valid(); iter2.Next() {
-// 		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter2.Key())
-// 		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter2.Value())
-
-// 		i--
-// 		count++
-// 	}
-// 	s.Require().Equal(9, count)
-// 	s.Require().NoError(iter2.Error())
-
-// 	// seek past domain, which should make the iterator invalid and produce an error
-// 	iter2.Next()
-// 	s.Require().False(iter2.Valid())
-
-// 	// start must be <= end
-// 	iter3, err := db.ReverseIterator(storeKey1, 1, []byte("key020"), []byte("key019"))
-// 	s.Require().Error(err)
-// 	s.Require().Nil(iter3)
-// }
-
-// func (s *StorageTestSuite) TestParallelWrites() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	latestVersion := 10
-// 	kvCount := 100
-
-// 	wg := sync.WaitGroup{}
-// 	triggerStartCh := make(chan bool)
-
-// 	// start 10 goroutines that write to the database
-// 	for i := 0; i < latestVersion; i++ {
-// 		wg.Add(1)
-// 		go func(i int) {
-// 			<-triggerStartCh
-// 			defer wg.Done()
-// 			keys := [][]byte{}
-// 			vals := [][]byte{}
-// 			for j := 0; j < kvCount; j++ {
-// 				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
-// 				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
-// 			}
-// 			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
-// 		}(i)
-
-// 	}
-
-// 	// start the goroutines
-// 	close(triggerStartCh)
-// 	wg.Wait()
-
-// 	// check that all the data is there
-// 	for i := 0; i < latestVersion; i++ {
-// 		for j := 0; j < kvCount; j++ {
-// 			version := int64(i + 1)
-// 			key := fmt.Sprintf("key-%d-%03d", i, j)
-// 			val := fmt.Sprintf("val-%d-%03d", i, j)
-
-// 			v, err := db.Get(storeKey1, version, []byte(key))
-// 			s.Require().NoError(err)
-// 			s.Require().Equal([]byte(val), v)
-// 		}
-// 	}
-// }
-
-// func (s *StorageTestSuite) TestParallelWriteAndPruning() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	latestVersion := 100
-// 	kvCount := 100
-// 	prunePeriod := 5
-
-// 	wg := sync.WaitGroup{}
-// 	triggerStartCh := make(chan bool)
-
-// 	// start a goroutine that write to the database
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-// 		for i := 0; i < latestVersion; i++ {
-// 			keys := [][]byte{}
-// 			vals := [][]byte{}
-// 			for j := 0; j < kvCount; j++ {
-// 				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
-// 				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
-// 			}
-// 			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
-// 		}
-// 	}()
-
-// 	// start a goroutine that prunes the database
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-// 		for i := 10; i < latestVersion; i += prunePeriod {
-// 			for {
-// 				v, err := db.GetLatestVersion()
-// 				s.Require().NoError(err)
-// 				if v > int64(i) {
-// 					s.Require().NoError(db.Prune(v - 1))
-// 					break
-// 				}
-// 			}
-// 		}
-// 	}()
-
-// 	// wait for the goroutines
-// 	close(triggerStartCh)
-// 	wg.Wait()
-
-// 	// check if the data is pruned
-// 	version := int64(latestVersion - prunePeriod)
-// 	val, err := db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
-// 	s.Require().Nil(err)
-// 	s.Require().Nil(val)
-
-// 	version = int64(latestVersion)
-// 	val, err = db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
-// 	s.Require().NoError(err)
-// 	s.Require().Equal([]byte(fmt.Sprintf("val-%d-%03d", version-1, 0)), val)
-// }
-
-// func (s *StorageTestSuite) TestDatabaseParallelDeleteIteration() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 100, 100))
-
-// 	wg := sync.WaitGroup{}
-// 	triggerStartCh := make(chan bool)
-
-// 	latestVersion := 100
-// 	kvCount := 100
-
-// 	// start a goroutine that deletes from the database at latest Version
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-
-// 		for j := 0; j < kvCount; j++ {
-// 			if j%10 == 0 {
-// 				key := []byte(fmt.Sprintf("key%03d", j))
-// 				s.Require().NoError(DBApplyChangeset(db, int64(latestVersion), storeKey1, [][]byte{key}, [][]byte{nil}))
-// 			}
-// 		}
-// 	}()
-
-// 	// start a goroutine that iterates over the database
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-// 		// iterator without an end key over multiple versions
-// 		for v := int64(1); v < 5; v++ {
-// 			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
-// 			s.Require().NoError(err)
-
-// 			defer itr.Close()
-
-// 			var i, count int
-// 			for ; itr.Valid(); itr.Next() {
-// 				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-// 				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
-
-// 				i++
-// 				count++
-// 			}
-// 			s.Require().Equal(100, count)
-// 			s.Require().NoError(itr.Error())
-
-// 			// seek past domain, which should make the iterator invalid and produce an error
-// 			itr.Next()
-// 			s.Require().False(itr.Valid())
-// 		}
-// 	}()
-
-// 	// wait for the goroutines
-// 	close(triggerStartCh)
-// 	wg.Wait()
-
-// 	// Verify deletes
-// 	for j := 0; j < 100; j++ {
-// 		ok, err := db.Has(storeKey1, int64(latestVersion), []byte(fmt.Sprintf("key%03d", j)))
-// 		s.Require().NoError(err)
-
-// 		if j%10 == 0 {
-// 			s.Require().False(ok)
-// 		} else {
-// 			s.Require().True(ok)
-// 		}
-// 	}
-// }
-
-// func (s *StorageTestSuite) TestDatabaseParallelWriteDelete() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 100, 1))
-
-// 	wg := sync.WaitGroup{}
-// 	triggerStartCh := make(chan bool)
-
-// 	latestVersion := int64(2)
-
-// 	// start a goroutine that writes to the database at latestVersion
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-
-// 		cs := &iavl.ChangeSet{}
-// 		cs.Pairs = []*iavl.KVPair{}
-
-// 		for i := 0; i < 50; i++ {
-// 			// Apply changeset for each key separately
-// 			key := []byte(fmt.Sprintf("key%03d", i))
-// 			val := []byte(fmt.Sprintf("val%03d", i))
-// 			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{val}))
-// 		}
-// 	}()
-
-// 	// start a goroutine that deletes from the database
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-
-// 		cs := &iavl.ChangeSet{}
-// 		cs.Pairs = []*iavl.KVPair{}
-
-// 		for i := 50; i < 100; i++ {
-// 			// Apply changeset for each key separately
-// 			key := []byte(fmt.Sprintf("key%03d", i))
-// 			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{nil}))
-// 		}
-// 	}()
-
-// 	// wait for the goroutines
-// 	close(triggerStartCh)
-// 	wg.Wait()
-
-// 	// Verify writes and deletes on latest version
-// 	for j := 0; j < 100; j++ {
-// 		ok, err := db.Has(storeKey1, latestVersion, []byte(fmt.Sprintf("key%03d", j)))
-// 		s.Require().NoError(err)
-
-// 		if j >= 50 {
-// 			s.Require().False(ok)
-// 		} else {
-// 			s.Require().True(ok)
-// 		}
-// 	}
-// }
-
-// func (s *StorageTestSuite) TestParallelIterationAndPruning() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 10, 50))
-
-// 	latestVersion := 50
-// 	numHeightsPruned := 20
-// 	prunePeriod := 5
-
-// 	wg := sync.WaitGroup{}
-// 	triggerStartCh := make(chan bool)
-
-// 	// start a goroutine that prunes the database
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-// 		for i := 10; i <= latestVersion-numHeightsPruned; i += prunePeriod {
-// 			s.Require().NoError(db.Prune(int64(i)))
-// 		}
-// 	}()
-
-// 	// start a goroutine that iterates over the database
-// 	wg.Add(1)
-// 	go func() {
-// 		<-triggerStartCh
-// 		defer wg.Done()
-// 		// iterator without an end key over multiple versions
-// 		for v := int64(latestVersion - numHeightsPruned + 1); v < int64(latestVersion); v++ {
-// 			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
-// 			s.Require().NoError(err)
-
-// 			defer itr.Close()
-
-// 			var i, count int
-// 			for ; itr.Valid(); itr.Next() {
-// 				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-// 				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
-
-// 				i++
-// 				count++
-// 			}
-// 			s.Require().Equal(10, count)
-// 			s.Require().NoError(itr.Error())
-
-// 			// seek past domain, which should make the iterator invalid and produce an error
-// 			itr.Next()
-// 			s.Require().False(itr.Valid())
-// 		}
-// 	}()
-
-// 	// wait for the goroutines
-// 	close(triggerStartCh)
-// 	wg.Wait()
-
-// 	// Ensure all keys are no longer present up to latestVersion - 20 and
-// 	// all keys are present after
-// 	for v := int64(1); v <= int64(latestVersion); v++ {
-// 		for i := 0; i < 10; i++ {
-// 			key := fmt.Sprintf("key%03d", i)
-// 			val := fmt.Sprintf("val%03d-%03d", i, v)
-
-// 			bz, err := db.Get(storeKey1, v, []byte(key))
-// 			s.Require().NoError(err)
-// 			if v <= int64(latestVersion-numHeightsPruned) {
-// 				s.Require().Nil(bz)
-// 			} else {
-// 				s.Require().Equal([]byte(val), bz)
-// 			}
-// 		}
-// 	}
-// }
-
-// func (s *StorageTestSuite) TestDatabaseParallelIterationVersions() {
-// 	db, err := s.NewDB(s.T().TempDir())
-// 	s.Require().NoError(err)
-// 	defer db.Close()
-
-// 	s.Require().NoError(FillData(db, 10, 100))
-
-// 	wg := sync.WaitGroup{}
-// 	triggerStartCh := make(chan bool)
-
-// 	latestVersion := 100
-// 	kvCount := 10
-
-// 	// start multiple goroutines that iterate over different version of the database
-// 	for v := 1; v < latestVersion; v++ {
-// 		wg.Add(1)
-// 		go func(v int) {
-// 			<-triggerStartCh
-// 			defer wg.Done()
-
-// 			itr, err := db.Iterator(storeKey1, int64(v), []byte("key000"), nil)
-// 			s.Require().NoError(err)
-
-// 			defer itr.Close()
-
-// 			var i, count int
-// 			for ; itr.Valid(); itr.Next() {
-// 				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-// 				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
-
-// 				i++
-// 				count++
-// 			}
-// 			s.Require().Equal(kvCount, count)
-// 			s.Require().NoError(itr.Error())
-
-// 			// seek past domain, which should make the iterator invalid and produce an error
-// 			itr.Next()
-// 			s.Require().False(itr.Valid())
-
-// 		}(v)
-// 	}
-
-// 	// wait for the goroutines
-// 	close(triggerStartCh)
-// 	wg.Wait()
-// }
+func (s *StorageTestSuite) TestDatabaseIteratorNoDomain() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 10, 50))
+
+	// create an iterator over the entire domain
+	itr, err := db.Iterator(storeKey1, 50, nil, nil)
+	s.Require().NoError(err)
+
+	defer itr.Close()
+
+	var i, count int
+	for ; itr.Valid(); itr.Next() {
+		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+		s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, 50)), itr.Value())
+
+		i++
+		count++
+	}
+	s.Require().Equal(10, count)
+	s.Require().NoError(itr.Error())
+}
+
+func (s *StorageTestSuite) TestDatabasePrune() {
+	if slices.Contains(s.SkipTests, s.T().Name()) {
+		s.T().SkipNow()
+	}
+
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 10, 50))
+
+	// prune the first 25 versions
+	s.Require().NoError(db.Prune(25))
+
+	latestVersion, err := db.GetLatestVersion()
+	s.Require().NoError(err)
+	s.Require().Equal(int64(50), latestVersion)
+
+	// Ensure all keys are no longer present up to and including version 25 and
+	// all keys are present after version 25.
+	for v := int64(1); v <= 50; v++ {
+		for i := 0; i < 10; i++ {
+			key := fmt.Sprintf("key%03d", i)
+			val := fmt.Sprintf("val%03d-%03d", i, v)
+
+			bz, err := db.Get(storeKey1, v, []byte(key))
+			s.Require().NoError(err)
+			if v <= 25 {
+				s.Require().Nil(bz)
+			} else {
+				s.Require().Equal([]byte(val), bz)
+			}
+		}
+	}
+
+	itr, err := db.Iterator(storeKey1, 25, []byte("key000"), nil)
+	s.Require().NoError(err)
+	s.Require().False(itr.Valid())
+
+	// prune the latest version which should prune the entire dataset
+	s.Require().NoError(db.Prune(50))
+
+	for v := int64(1); v <= 50; v++ {
+		for i := 0; i < 10; i++ {
+			key := fmt.Sprintf("key%03d", i)
+
+			bz, err := db.Get(storeKey1, v, []byte(key))
+			s.Require().NoError(err)
+			s.Require().Nil(bz)
+		}
+	}
+}
+
+func (s *StorageTestSuite) TestDatabasePruneKeepRecent() {
+	if slices.Contains(s.SkipTests, s.T().Name()) {
+		s.T().SkipNow()
+	}
+
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	key := []byte("key000")
+
+	// write a key at three different versions 1, 100 and 200
+	s.Require().NoError(DBApplyChangeset(db, 1, storeKey1, [][]byte{key}, [][]byte{[]byte("value001")}))
+	s.Require().NoError(DBApplyChangeset(db, 100, storeKey1, [][]byte{key}, [][]byte{[]byte("value002")}))
+	s.Require().NoError(DBApplyChangeset(db, 200, storeKey1, [][]byte{key}, [][]byte{[]byte("value003")}))
+
+	// prune version 50
+	s.Require().NoError(db.Prune(50))
+
+	// ensure queries for versions 50 and older return nil
+	bz, err := db.Get(storeKey1, 49, key)
+	s.Require().Nil(err)
+	s.Require().Nil(bz)
+
+	itr, err := db.Iterator(storeKey1, 49, nil, nil)
+	s.Require().NoError(err)
+	s.Require().False(itr.Valid())
+
+	defer itr.Close()
+
+	// ensure the value previously at version 1 is still there for queries greater than 50
+	bz, err = db.Get(storeKey1, 51, key)
+	s.Require().NoError(err)
+	s.Require().Equal([]byte("value001"), bz)
+
+	// ensure the correct value at a greater height
+	bz, err = db.Get(storeKey1, 200, key)
+	s.Require().NoError(err)
+	s.Require().Equal([]byte("value003"), bz)
+
+	// prune latest height and ensure we have the previous version when querying above it
+	s.Require().NoError(db.Prune(200))
+
+	bz, err = db.Get(storeKey1, 201, key)
+	s.Require().NoError(err)
+	s.Require().Equal([]byte("value003"), bz)
+}
+
+func (s *StorageTestSuite) TestDatabaseReverseIterator() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 100, 1))
+
+	// reverse iterator without an end key
+	iter, err := db.ReverseIterator(storeKey1, 1, []byte("key000"), nil)
+	s.Require().NoError(err)
+
+	defer iter.Close()
+
+	i, count := 99, 0
+	for ; iter.Valid(); iter.Next() {
+		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter.Key())
+		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter.Value())
+
+		i--
+		count++
+	}
+	s.Require().Equal(100, count)
+	s.Require().NoError(iter.Error())
+
+	// seek past domain, which should make the iterator invalid and produce an error
+	iter.Next()
+	s.Require().False(iter.Valid())
+
+	// reverse iterator with with a start and end domain
+	iter2, err := db.ReverseIterator(storeKey1, 1, []byte("key010"), []byte("key019"))
+	s.Require().NoError(err)
+
+	defer iter2.Close()
+
+	i, count = 18, 0
+	for ; iter2.Valid(); iter2.Next() {
+		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), iter2.Key())
+		s.Require().Equal([]byte(fmt.Sprintf("val%03d-001", i)), iter2.Value())
+
+		i--
+		count++
+	}
+	s.Require().Equal(9, count)
+	s.Require().NoError(iter2.Error())
+
+	// seek past domain, which should make the iterator invalid and produce an error
+	iter2.Next()
+	s.Require().False(iter2.Valid())
+
+	// start must be <= end
+	iter3, err := db.ReverseIterator(storeKey1, 1, []byte("key020"), []byte("key019"))
+	s.Require().Error(err)
+	s.Require().Nil(iter3)
+}
+
+func (s *StorageTestSuite) TestParallelWrites() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	latestVersion := 10
+	kvCount := 100
+
+	wg := sync.WaitGroup{}
+	triggerStartCh := make(chan bool)
+
+	// start 10 goroutines that write to the database
+	for i := 0; i < latestVersion; i++ {
+		wg.Add(1)
+		go func(i int) {
+			<-triggerStartCh
+			defer wg.Done()
+			keys := [][]byte{}
+			vals := [][]byte{}
+			for j := 0; j < kvCount; j++ {
+				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
+				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
+			}
+			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
+		}(i)
+
+	}
+
+	// start the goroutines
+	close(triggerStartCh)
+	wg.Wait()
+
+	// check that all the data is there
+	for i := 0; i < latestVersion; i++ {
+		for j := 0; j < kvCount; j++ {
+			version := int64(i + 1)
+			key := fmt.Sprintf("key-%d-%03d", i, j)
+			val := fmt.Sprintf("val-%d-%03d", i, j)
+
+			v, err := db.Get(storeKey1, version, []byte(key))
+			s.Require().NoError(err)
+			s.Require().Equal([]byte(val), v)
+		}
+	}
+}
+
+func (s *StorageTestSuite) TestParallelWriteAndPruning() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	latestVersion := 100
+	kvCount := 100
+	prunePeriod := 5
+
+	wg := sync.WaitGroup{}
+	triggerStartCh := make(chan bool)
+
+	// start a goroutine that write to the database
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+		for i := 0; i < latestVersion; i++ {
+			keys := [][]byte{}
+			vals := [][]byte{}
+			for j := 0; j < kvCount; j++ {
+				keys = append(keys, []byte(fmt.Sprintf("key-%d-%03d", i, j)))
+				vals = append(vals, []byte(fmt.Sprintf("val-%d-%03d", i, j)))
+			}
+			s.Require().NoError(DBApplyChangeset(db, int64(i+1), storeKey1, keys, vals))
+		}
+	}()
+
+	// start a goroutine that prunes the database
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+		for i := 10; i < latestVersion; i += prunePeriod {
+			for {
+				v, err := db.GetLatestVersion()
+				s.Require().NoError(err)
+				if v > int64(i) {
+					s.Require().NoError(db.Prune(v - 1))
+					break
+				}
+			}
+		}
+	}()
+
+	// wait for the goroutines
+	close(triggerStartCh)
+	wg.Wait()
+
+	// check if the data is pruned
+	version := int64(latestVersion - prunePeriod)
+	val, err := db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
+	s.Require().Nil(err)
+	s.Require().Nil(val)
+
+	version = int64(latestVersion)
+	val, err = db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
+	s.Require().NoError(err)
+	s.Require().Equal([]byte(fmt.Sprintf("val-%d-%03d", version-1, 0)), val)
+}
+
+func (s *StorageTestSuite) TestDatabaseParallelDeleteIteration() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 100, 100))
+
+	wg := sync.WaitGroup{}
+	triggerStartCh := make(chan bool)
+
+	latestVersion := 100
+	kvCount := 100
+
+	// start a goroutine that deletes from the database at latest Version
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+
+		for j := 0; j < kvCount; j++ {
+			if j%10 == 0 {
+				key := []byte(fmt.Sprintf("key%03d", j))
+				s.Require().NoError(DBApplyChangeset(db, int64(latestVersion), storeKey1, [][]byte{key}, [][]byte{nil}))
+			}
+		}
+	}()
+
+	// start a goroutine that iterates over the database
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+		// iterator without an end key over multiple versions
+		for v := int64(1); v < 5; v++ {
+			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
+			s.Require().NoError(err)
+
+			defer itr.Close()
+
+			var i, count int
+			for ; itr.Valid(); itr.Next() {
+				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
+
+				i++
+				count++
+			}
+			s.Require().Equal(100, count)
+			s.Require().NoError(itr.Error())
+
+			// seek past domain, which should make the iterator invalid and produce an error
+			itr.Next()
+			s.Require().False(itr.Valid())
+		}
+	}()
+
+	// wait for the goroutines
+	close(triggerStartCh)
+	wg.Wait()
+
+	// Verify deletes
+	for j := 0; j < 100; j++ {
+		ok, err := db.Has(storeKey1, int64(latestVersion), []byte(fmt.Sprintf("key%03d", j)))
+		s.Require().NoError(err)
+
+		if j%10 == 0 {
+			s.Require().False(ok)
+		} else {
+			s.Require().True(ok)
+		}
+	}
+}
+
+func (s *StorageTestSuite) TestDatabaseParallelWriteDelete() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 100, 1))
+
+	wg := sync.WaitGroup{}
+	triggerStartCh := make(chan bool)
+
+	latestVersion := int64(2)
+
+	// start a goroutine that writes to the database at latestVersion
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+
+		cs := &iavl.ChangeSet{}
+		cs.Pairs = []*iavl.KVPair{}
+
+		for i := 0; i < 50; i++ {
+			// Apply changeset for each key separately
+			key := []byte(fmt.Sprintf("key%03d", i))
+			val := []byte(fmt.Sprintf("val%03d", i))
+			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{val}))
+		}
+	}()
+
+	// start a goroutine that deletes from the database
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+
+		cs := &iavl.ChangeSet{}
+		cs.Pairs = []*iavl.KVPair{}
+
+		for i := 50; i < 100; i++ {
+			// Apply changeset for each key separately
+			key := []byte(fmt.Sprintf("key%03d", i))
+			s.Require().NoError(DBApplyChangeset(db, latestVersion, storeKey1, [][]byte{key}, [][]byte{nil}))
+		}
+	}()
+
+	// wait for the goroutines
+	close(triggerStartCh)
+	wg.Wait()
+
+	// Verify writes and deletes on latest version
+	for j := 0; j < 100; j++ {
+		ok, err := db.Has(storeKey1, latestVersion, []byte(fmt.Sprintf("key%03d", j)))
+		s.Require().NoError(err)
+
+		if j >= 50 {
+			s.Require().False(ok)
+		} else {
+			s.Require().True(ok)
+		}
+	}
+}
+
+func (s *StorageTestSuite) TestParallelIterationAndPruning() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 10, 50))
+
+	latestVersion := 50
+	numHeightsPruned := 20
+	prunePeriod := 5
+
+	wg := sync.WaitGroup{}
+	triggerStartCh := make(chan bool)
+
+	// start a goroutine that prunes the database
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+		for i := 10; i <= latestVersion-numHeightsPruned; i += prunePeriod {
+			s.Require().NoError(db.Prune(int64(i)))
+		}
+	}()
+
+	// start a goroutine that iterates over the database
+	wg.Add(1)
+	go func() {
+		<-triggerStartCh
+		defer wg.Done()
+		// iterator without an end key over multiple versions
+		for v := int64(latestVersion - numHeightsPruned + 1); v < int64(latestVersion); v++ {
+			itr, err := db.Iterator(storeKey1, v, []byte("key000"), nil)
+			s.Require().NoError(err)
+
+			defer itr.Close()
+
+			var i, count int
+			for ; itr.Valid(); itr.Next() {
+				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
+
+				i++
+				count++
+			}
+			s.Require().Equal(10, count)
+			s.Require().NoError(itr.Error())
+
+			// seek past domain, which should make the iterator invalid and produce an error
+			itr.Next()
+			s.Require().False(itr.Valid())
+		}
+	}()
+
+	// wait for the goroutines
+	close(triggerStartCh)
+	wg.Wait()
+
+	// Ensure all keys are no longer present up to latestVersion - 20 and
+	// all keys are present after
+	for v := int64(1); v <= int64(latestVersion); v++ {
+		for i := 0; i < 10; i++ {
+			key := fmt.Sprintf("key%03d", i)
+			val := fmt.Sprintf("val%03d-%03d", i, v)
+
+			bz, err := db.Get(storeKey1, v, []byte(key))
+			s.Require().NoError(err)
+			if v <= int64(latestVersion-numHeightsPruned) {
+				s.Require().Nil(bz)
+			} else {
+				s.Require().Equal([]byte(val), bz)
+			}
+		}
+	}
+}
+
+func (s *StorageTestSuite) TestDatabaseParallelIterationVersions() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	s.Require().NoError(FillData(db, 10, 100))
+
+	wg := sync.WaitGroup{}
+	triggerStartCh := make(chan bool)
+
+	latestVersion := 100
+	kvCount := 10
+
+	// start multiple goroutines that iterate over different version of the database
+	for v := 1; v < latestVersion; v++ {
+		wg.Add(1)
+		go func(v int) {
+			<-triggerStartCh
+			defer wg.Done()
+
+			itr, err := db.Iterator(storeKey1, int64(v), []byte("key000"), nil)
+			s.Require().NoError(err)
+
+			defer itr.Close()
+
+			var i, count int
+			for ; itr.Valid(); itr.Next() {
+				s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+				s.Require().Equal([]byte(fmt.Sprintf("val%03d-%03d", i, v)), itr.Value())
+
+				i++
+				count++
+			}
+			s.Require().Equal(kvCount, count)
+			s.Require().NoError(itr.Error())
+
+			// seek past domain, which should make the iterator invalid and produce an error
+			itr.Next()
+			s.Require().False(itr.Valid())
+
+		}(v)
+	}
+
+	// wait for the goroutines
+	close(triggerStartCh)
+	wg.Wait()
+}


### PR DESCRIPTION
## Describe your changes and provide context
- Fix for PebbleDB Iterator issue
- Previously, the mvcc iterator would loop indefinitely when it reached a key that was greater than the iterator version specified and go back to a previous key
- Catch the scenario where iterator moves back to previous key and move it forward to avoid a loop

## Testing performed to validate your change
- Tested and repro'd error on node 

Before fix: 
![image](https://github.com/sei-protocol/sei-db/assets/22248919/9fd6040b-e3dc-4274-ab9c-4be127a38bc6)

After fix:
![image](https://github.com/sei-protocol/sei-db/assets/22248919/7aab3c3a-48e9-44ec-a923-b4a7af557f73)

