### PR TITLE
Prune Batch Reset

### DIFF
--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -331,8 +331,7 @@ func (db *Database) Prune(version int64) error {
 				}
 
 				counter = 0
-				batch = db.storage.NewBatch()
-				defer batch.Close()
+				batch.Reset()
 			}
 		}
 


### PR DESCRIPTION
## Describe your changes and provide context
- Addresses issue where during pruning OOM occurs since the batch's are not freed properly
- use batch.Reset instead of batch.Close

## Testing performed to validate your change
- Testing on node
- Looking into how to add unit tests
