### PR TITLE
Improve memiavl graceful shutdown

### DIFF
--- a/sc/memiavl/benchmark_test.go
+++ b/sc/memiavl/benchmark_test.go
@@ -2,6 +2,7 @@ package memiavl
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"math/rand"
 	"sort"
@@ -32,7 +33,7 @@ func BenchmarkRandomGet(b *testing.B) {
 	}
 
 	snapshotDir := b.TempDir()
-	err := tree.WriteSnapshot(snapshotDir)
+	err := tree.WriteSnapshot(context.Background(), snapshotDir)
 	require.NoError(b, err)
 	snapshot, err := OpenSnapshot(snapshotDir)
 	require.NoError(b, err)

--- a/sc/memiavl/db_test.go
+++ b/sc/memiavl/db_test.go
@@ -1,6 +1,7 @@
 package memiavl
 
 import (
+	"context"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ func TestRewriteSnapshot(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, i+1, int(v))
 			require.Equal(t, RefHashes[i], db.lastCommitInfo.StoreInfos[0].CommitId.Hash)
-			require.NoError(t, db.RewriteSnapshot())
+			require.NoError(t, db.RewriteSnapshot(context.Background()))
 			require.NoError(t, db.Reload())
 		})
 	}
@@ -250,7 +251,7 @@ func TestInitialVersion(t *testing.T) {
 		// the nodes are created with version 1, which is compatible with iavl behavior: https://github.com/cosmos/iavl/pull/660
 		require.Equal(t, info.CommitId.Hash, HashNode(newLeafNode([]byte(key), []byte(value), 1)))
 
-		require.NoError(t, db.RewriteSnapshot())
+		require.NoError(t, db.RewriteSnapshot(context.Background()))
 		require.NoError(t, db.Reload())
 
 		db.ApplyUpgrades([]*proto.TreeNameUpgrade{{Name: name2}})
@@ -326,7 +327,7 @@ func TestZeroCopy(t *testing.T) {
 	_, err = db.Commit()
 	require.NoError(t, err)
 	require.NoError(t, errors.Join(
-		db.RewriteSnapshot(),
+		db.RewriteSnapshot(context.Background()),
 		db.Reload(),
 	))
 

--- a/sc/memiavl/import.go
+++ b/sc/memiavl/import.go
@@ -1,6 +1,7 @@
 package memiavl
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -134,7 +135,7 @@ func doImport(dir string, version int64, nodes <-chan *types.SnapshotNode) (retu
 		return errors.New("version overflows uint32")
 	}
 
-	return writeSnapshot(dir, uint32(version), func(w *snapshotWriter) (uint32, error) {
+	return writeSnapshot(context.Background(), dir, uint32(version), func(w *snapshotWriter) (uint32, error) {
 		i := &importer{
 			snapshotWriter: *w,
 		}

--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -356,7 +356,7 @@ func (t *MultiTree) Catchup(stream types.Stream[proto.ChangelogEntry], endVersio
 	return nil
 }
 
-func (t *MultiTree) WriteSnapshot(dir string, wp *pond.WorkerPool) error {
+func (t *MultiTree) WriteSnapshot(ctx context.Context, dir string, wp *pond.WorkerPool) error {
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func (t *MultiTree) WriteSnapshot(dir string, wp *pond.WorkerPool) error {
 	for _, entry := range t.trees {
 		tree, name := entry.Tree, entry.Name
 		group.Submit(func() error {
-			return tree.WriteSnapshot(filepath.Join(dir, name))
+			return tree.WriteSnapshot(ctx, filepath.Join(dir, name))
 		})
 	}
 

--- a/sc/memiavl/proof_test.go
+++ b/sc/memiavl/proof_test.go
@@ -1,6 +1,7 @@
 package memiavl
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestProofs(t *testing.T) {
 			require.True(t, tree.VerifyNonMembership(proof, tc.nonExistKey))
 
 			// test persisted tree
-			require.NoError(t, tree.WriteSnapshot(tmpDir))
+			require.NoError(t, tree.WriteSnapshot(context.Background(), tmpDir))
 			snapshot, err := OpenSnapshot(tmpDir)
 			require.NoError(t, err)
 			ptree := NewFromSnapshot(snapshot, true, 0)

--- a/sc/memiavl/snapshot.go
+++ b/sc/memiavl/snapshot.go
@@ -356,6 +356,7 @@ func (t *Tree) WriteSnapshot(ctx context.Context, snapshotDir string) error {
 		if t.root == nil {
 			return 0, nil
 		}
+
 		if err := w.writeRecursive(t.root); err != nil {
 			return 0, err
 		}
@@ -509,11 +510,6 @@ func (w *snapshotWriter) writeKeyValue(key, value []byte) error {
 }
 
 func (w *snapshotWriter) writeLeaf(version uint32, key, value, hash []byte) error {
-	select {
-	case <-w.ctx.Done():
-		return w.ctx.Err()
-	default:
-	}
 	var buf [SizeLeafWithoutHash]byte
 	binary.LittleEndian.PutUint32(buf[OffsetLeafVersion:], version)
 	binary.LittleEndian.PutUint32(buf[OffsetLeafKeyLen:], uint32(len(key)))
@@ -556,6 +552,11 @@ func (w *snapshotWriter) writeBranch(version, size uint32, height, preTrees uint
 // writeRecursive write the node recursively in depth-first post-order,
 // returns `(nodeIndex, err)`.
 func (w *snapshotWriter) writeRecursive(node Node) error {
+	select {
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	default:
+	}
 	if node.IsLeaf() {
 		return w.writeLeaf(node.Version(), node.Key(), node.Value(), node.Hash())
 	}

--- a/sc/memiavl/snapshot.go
+++ b/sc/memiavl/snapshot.go
@@ -510,10 +510,6 @@ func (w *snapshotWriter) writeKeyValue(key, value []byte) error {
 }
 
 func (w *snapshotWriter) writeLeaf(version uint32, key, value, hash []byte) error {
-	select {
-	case <-w.ctx.Done():
-		return w.ctx.Err()
-	}
 	var buf [SizeLeafWithoutHash]byte
 	binary.LittleEndian.PutUint32(buf[OffsetLeafVersion:], version)
 	binary.LittleEndian.PutUint32(buf[OffsetLeafKeyLen:], uint32(len(key)))
@@ -556,7 +552,11 @@ func (w *snapshotWriter) writeBranch(version, size uint32, height, preTrees uint
 // writeRecursive write the node recursively in depth-first post-order,
 // returns `(nodeIndex, err)`.
 func (w *snapshotWriter) writeRecursive(node Node) error {
-
+	select {
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	default:
+	}
 	if node.IsLeaf() {
 		return w.writeLeaf(node.Version(), node.Key(), node.Value(), node.Hash())
 	}

--- a/sc/memiavl/snapshot.go
+++ b/sc/memiavl/snapshot.go
@@ -510,6 +510,10 @@ func (w *snapshotWriter) writeKeyValue(key, value []byte) error {
 }
 
 func (w *snapshotWriter) writeLeaf(version uint32, key, value, hash []byte) error {
+	select {
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	}
 	var buf [SizeLeafWithoutHash]byte
 	binary.LittleEndian.PutUint32(buf[OffsetLeafVersion:], version)
 	binary.LittleEndian.PutUint32(buf[OffsetLeafKeyLen:], uint32(len(key)))
@@ -552,11 +556,7 @@ func (w *snapshotWriter) writeBranch(version, size uint32, height, preTrees uint
 // writeRecursive write the node recursively in depth-first post-order,
 // returns `(nodeIndex, err)`.
 func (w *snapshotWriter) writeRecursive(node Node) error {
-	select {
-	case <-w.ctx.Done():
-		return w.ctx.Err()
-	default:
-	}
+
 	if node.IsLeaf() {
 		return w.writeLeaf(node.Version(), node.Key(), node.Value(), node.Hash())
 	}

--- a/sc/memiavl/snapshot_test.go
+++ b/sc/memiavl/snapshot_test.go
@@ -1,6 +1,7 @@
 package memiavl
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestSnapshotEncodingRoundTrip(t *testing.T) {
 	}
 
 	snapshotDir := t.TempDir()
-	require.NoError(t, tree.WriteSnapshot(snapshotDir))
+	require.NoError(t, tree.WriteSnapshot(context.Background(), snapshotDir))
 
 	snapshot, err := OpenSnapshot(snapshotDir)
 	require.NoError(t, err)
@@ -71,7 +72,7 @@ func TestSnapshotExport(t *testing.T) {
 	}
 
 	snapshotDir := t.TempDir()
-	require.NoError(t, tree.WriteSnapshot(snapshotDir))
+	require.NoError(t, tree.WriteSnapshot(context.Background(), snapshotDir))
 
 	snapshot, err := OpenSnapshot(snapshotDir)
 	require.NoError(t, err)
@@ -100,7 +101,7 @@ func TestSnapshotImportExport(t *testing.T) {
 	}
 
 	snapshotDir := t.TempDir()
-	require.NoError(t, tree.WriteSnapshot(snapshotDir))
+	require.NoError(t, tree.WriteSnapshot(context.Background(), snapshotDir))
 	snapshot, err := OpenSnapshot(snapshotDir)
 	require.NoError(t, err)
 
@@ -161,7 +162,7 @@ func TestDBSnapshotRestore(t *testing.T) {
 		testSnapshotRoundTrip(t, db)
 	}
 
-	require.NoError(t, db.RewriteSnapshot())
+	require.NoError(t, db.RewriteSnapshot(context.Background()))
 	require.NoError(t, db.Reload())
 	require.Equal(t, len(ChangeSets), int(db.metadata.CommitInfo.Version))
 	testSnapshotRoundTrip(t, db)

--- a/sc/memiavl/tree_test.go
+++ b/sc/memiavl/tree_test.go
@@ -1,6 +1,7 @@
 package memiavl
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -254,7 +255,7 @@ func TestGetByIndex(t *testing.T) {
 
 	// test persisted tree
 	dir := t.TempDir()
-	require.NoError(t, tree.WriteSnapshot(dir))
+	require.NoError(t, tree.WriteSnapshot(context.Background(), dir))
 	snapshot, err := OpenSnapshot(dir)
 	require.NoError(t, err)
 	ptree := NewFromSnapshot(snapshot, true, 0)

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -318,7 +318,7 @@ func (db *Database) Prune(version int64) error {
 		// Delete a key if another entry for that key exists a larger version than original but leq to the prune height
 		// Also delete a key if it has been tombstoned and its version is leq to the prune height
 		if prevVersionDecoded <= version && (bytes.Equal(prevKey, currKey) || valTombstoned(prevValEncoded)) {
-			err = batch.Delete(prevKeyEncoded, defaultWriteOpts)
+			err = batch.Delete(prevKeyEncoded, nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Describe your changes and provide context
During shutdown process,  currently when MemIAVL is taking a snapshot, it will throw panic with segmentation fault. 
This PR mostly cherry pick the fix from https://github.com/crypto-org-chain/cronos/pull/1292.


## Testing performed to validate your change
Tested on a seidb node with manual restart
