### PR TITLE
[SeiDB] State Store Expose `GetEarliestVersion`

### DIFF
--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -145,8 +145,8 @@ func (db *Database) SetEarliestVersion(version int64) error {
 	return db.storage.Set([]byte(earliestVersionKey), ts[:], defaultWriteOpts)
 }
 
-func (db *Database) GetEarliestVersion() int64 {
-	return db.earliestVersion
+func (db *Database) GetEarliestVersion() (int64, error) {
+	return db.earliestVersion, nil
 }
 
 // Retrieves earliest version from db

--- a/ss/rocksdb/db.go
+++ b/ss/rocksdb/db.go
@@ -127,6 +127,14 @@ func (db *Database) GetLatestVersion() (int64, error) {
 	return int64(binary.LittleEndian.Uint64(bz)), nil
 }
 
+func (db *Database) SetEarliestVersion(version int64) error {
+	panic("not implemented")
+}
+
+func (db *Database) GetEarliestVersion() (int64, error) {
+	panic("not implemented")
+}
+
 func (db *Database) Has(storeKey string, version int64, key []byte) (bool, error) {
 	if version < db.tsLow {
 		return false, nil

--- a/ss/sqlite/db.go
+++ b/ss/sqlite/db.go
@@ -138,6 +138,14 @@ func (db *Database) SetLatestVersion(version int64) error {
 	return nil
 }
 
+func (db *Database) GetEarliestVersion() (int64, error) {
+	panic("not implemented")
+}
+
+func (db *Database) SetEarliestVersion(version int64) error {
+	panic("not implemented")
+}
+
 func (db *Database) Has(storeKey string, version int64, key []byte) (bool, error) {
 	val, err := db.Get(storeKey, version, key)
 	if err != nil {

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -522,8 +522,18 @@ func (s *StorageTestSuite) TestDatabasePrune() {
 
 	s.Require().NoError(FillData(db, 10, 50))
 
+	// Verify earliest version is 0
+	earliestVersion, err := db.GetEarliestVersion()
+	s.Require().NoError(err)
+	s.Require().Equal(int64(0), earliestVersion)
+
 	// prune the first 25 versions
 	s.Require().NoError(db.Prune(25))
+
+	// Verify earliest version is 26 (first 25 pruned)
+	earliestVersion, err = db.GetEarliestVersion()
+	s.Require().NoError(err)
+	s.Require().Equal(int64(26), earliestVersion)
 
 	latestVersion, err := db.GetLatestVersion()
 	s.Require().NoError(err)
@@ -552,6 +562,11 @@ func (s *StorageTestSuite) TestDatabasePrune() {
 
 	// prune the latest version which should prune the entire dataset
 	s.Require().NoError(db.Prune(50))
+
+	// Verify earliest version is 51 (first 50 pruned)
+	earliestVersion, err = db.GetEarliestVersion()
+	s.Require().NoError(err)
+	s.Require().Equal(int64(51), earliestVersion)
 
 	for v := int64(1); v <= 50; v++ {
 		for i := 0; i < 10; i++ {

--- a/ss/types/store.go
+++ b/ss/types/store.go
@@ -16,6 +16,8 @@ type StateStore interface {
 	RawIterate(storeKey string, fn func([]byte, []byte, int64) bool) (bool, error)
 	GetLatestVersion() (int64, error)
 	SetLatestVersion(version int64) error
+	GetEarliestVersion() (int64, error)
+	SetEarliestVersion(version int64) error
 
 	// ApplyChangeset Persist the change set of a block,
 	// the `changeSet` should be ordered by (storeKey, key),


### PR DESCRIPTION
## Describe your changes and provide context
- Expose `GetEarliestVersion` in State Store
- NOTE: Earliest version is only updating after a successful prune, not before or during

## Testing performed to validate your change
- Unit tests for earliest version
