### PR TITLE
Various fixes from audit

### DIFF
--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -731,12 +731,12 @@ func parseVersion(name string) (int64, error) {
 		return 0, fmt.Errorf("invalid snapshot name %s", name)
 	}
 
-	v, err := strconv.ParseInt(name[len(SnapshotPrefix):], 10, 32)
+	v, err := strconv.ParseUint(name[len(SnapshotPrefix):], 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("snapshot version overflows: %d", err)
 	}
 
-	return v, nil
+	return int64(v), nil
 }
 
 // seekSnapshot find the biggest snapshot version that's smaller than or equal to the target version,

--- a/sc/memiavl/layout_native.go
+++ b/sc/memiavl/layout_native.go
@@ -68,10 +68,6 @@ func (node *nodeLayout) KeyLeaf() uint32 {
 	return node.data[3]
 }
 
-func (node *nodeLayout) KeyOffset() uint64 {
-	return uint64(node.data[2]) | uint64(node.data[3])<<32
-}
-
 func (node *nodeLayout) Hash() []byte {
 	return node.hash[:]
 }

--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -362,7 +362,7 @@ func (t *MultiTree) WriteSnapshot(ctx context.Context, dir string, wp *pond.Work
 	}
 
 	// write the snapshots in parallel and wait all jobs done
-	group, _ := wp.GroupContext(context.Background())
+	group, _ := wp.GroupContext(ctx)
 
 	for _, entry := range t.trees {
 		tree, name := entry.Tree, entry.Name

--- a/sc/memiavl/tree.go
+++ b/sc/memiavl/tree.go
@@ -126,6 +126,7 @@ func (t *Tree) Copy(cacheSize int) *Tree {
 	newTree := *t
 	// cache is not copied along because it's not thread-safe to access
 	newTree.cache = NewCache(cacheSize)
+	newTree.mtx = &sync.RWMutex{}
 	return &newTree
 }
 

--- a/ss/store.go
+++ b/ss/store.go
@@ -46,6 +46,7 @@ func NewStateStore(homeDir string, ssConfig config.StateStoreConfig) (types.Stat
 	return db, nil
 }
 
+// RecoverStateStore will be called during initialization to recover the state from rlog
 func RecoverStateStore(homePath string, logger logger.Logger, stateStore types.StateStore) error {
 	ssLatestVersion, err := stateStore.GetLatestVersion()
 	if err != nil {
@@ -79,7 +80,7 @@ func RecoverStateStore(homePath string, logger logger.Logger, stateStore types.S
 	targetStartOffset := uint64(ssLatestVersion) - delta
 	logger.Info(fmt.Sprintf("Start replaying changelog to recover StateStore from offset %d to %d", targetStartOffset, lastOffset))
 	if targetStartOffset < lastOffset {
-		return streamHandler.Replay(targetStartOffset, lastOffset, func(index uint64, entry proto.ChangelogEntry) error {
+		return streamHandler.Replay(targetStartOffset+1, lastOffset, func(index uint64, entry proto.ChangelogEntry) error {
 			// commit to state store
 			for _, cs := range entry.Changesets {
 				if err := stateStore.ApplyChangeset(entry.Version, cs); err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
This PR address a few minor issues from audit:
- The replay [here](https://github.com/sei-protocol/sei-db/blob/main/ss/store.go#L82) should probably start from targetStartOffset + 1 instead of targetStartOffset, since ssLatestVersion is already in the db.

- I think deriving the group context from argument ctx instead of Background.Context makes more sense [here](https://github.com/sei-protocol/sei-db/blob/main/sc/memiavl/multitree.go#L365). Additionally, don't we want to use the context derived from wp.GroupContext for WriteSnapshot?

- It seems like we would like to allow version up to Uint32.Max, but strconv.ParseInt [here](https://github.com/sei-protocol/sei-db/blob/main/sc/memiavl/db.go#L734) can only handle up to Int32.Max for bitSize = 32. Using strconv.ParseUint would be a better choice.

- This function [here](https://github.com/sei-protocol/sei-db/blob/main/sc/memiavl/layout_native.go#L71) is both incorrect and unnecessary. Only leaves have KeyOffset.

- We should create a new mtx for Tree copies [here](https://github.com/sei-protocol/sei-db/blob/main/sc/memiavl/tree.go#L121) to prevent two trees from sharing the same lock.

## Testing performed to validate your change

