### PR TITLE
Bug Fix: Remove LRU cache on top of memiavl

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,7 @@ type StateCommitConfig struct {
 	SnapshotWriterLimit int `mapstructure:"snapshot-writer-limit"`
 
 	// CacheSize defines the size of the cache for each memiavl store.
-	// defaults to 100000.
+	// Deprecated: this is removed, we will just rely on mmap page cache
 	CacheSize int `mapstructure:"cache-size"`
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -32,9 +32,6 @@ sc-snapshot-interval = {{ .StateCommit.SnapshotInterval }}
 # SnapshotWriterLimit defines the max concurrency for taking commit store snapshot
 sc-snapshot-writer-limit = {{ .StateCommit.SnapshotWriterLimit }}
 
-# CacheSize defines the size of the LRU cache for each store on top of the tree, default to 100000.
-sc-cache-size = {{ .StateCommit.CacheSize }}
-
 [state-store]
 # Enable defines whether the state-store should be enabled for storing historical data.
 # Supporting historical queries or exporting state snapshot requires setting this to true

--- a/sc/memiavl/benchmark_test.go
+++ b/sc/memiavl/benchmark_test.go
@@ -68,7 +68,6 @@ func BenchmarkRandomGet(b *testing.B) {
 	b.Run("memiavl-disk-cache-miss", func(b *testing.B) {
 		diskTree := NewFromSnapshot(snapshot, true, 0)
 		// enforce an empty cache to emulate cache miss
-		diskTree.cache = iavlcache.New(0)
 		require.Equal(b, targetValue, diskTree.Get(targetKey))
 
 		b.ResetTimer()

--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -225,7 +225,7 @@ func (t *MultiTree) ApplyUpgrades(upgrades []*proto.TreeNameUpgrade) error {
 			t.trees[i].Name = upgrade.Name
 		default:
 			// add tree
-			tree := NewWithInitialVersion(uint32(utils.NextVersion(t.Version(), t.initialVersion)), t.cacheSize)
+			tree := NewWithInitialVersion(uint32(utils.NextVersion(t.Version(), t.initialVersion)))
 			t.trees = append(t.trees, NamedTree{Tree: tree, Name: upgrade.Name})
 		}
 	}


### PR DESCRIPTION
## Describe your changes and provide context
**Problem:**
We are seeing some unsafe/bug regards to this cache node that could cause a node to crash:
<img width="1344" alt="image" src="https://github.com/sei-protocol/sei-db/assets/50607998/5514ae31-d007-47d9-b714-5cdc659be371">

**Solution:**
The simple solution is to completely remove this LRU cache. With a recent benchmark we notice there isn't any improvement when we enable/disable this cache because mmap page cache already serves as a similar cache layer. Removing this would actually save some cpu usage. 

We can also rely on the inter-block-cache in cosmos layer for a real application cache.
## Testing performed to validate your change

