### PR TITLE
[SeiDB] Fix MemIAVL Race Condition during snapshot reload

### DIFF
--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -534,6 +534,7 @@ func (db *DB) reload() error {
 }
 
 func (db *DB) reloadMultiTree(mtree *MultiTree) error {
+	// catch-up the pending changes
 	if err := mtree.apply(db.pendingLogEntry); err != nil {
 		return err
 	}

--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -538,8 +538,7 @@ func (db *DB) reloadMultiTree(mtree *MultiTree) error {
 	if err := mtree.apply(db.pendingLogEntry); err != nil {
 		return err
 	}
-	db.MultiTree.ReplaceWith(mtree)
-	return nil
+	return db.MultiTree.ReplaceWith(mtree)
 }
 
 // rewriteIfApplicable execute the snapshot rewrite strategy according to current height

--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -534,13 +534,11 @@ func (db *DB) reload() error {
 }
 
 func (db *DB) reloadMultiTree(mtree *MultiTree) error {
-	if err := db.MultiTree.Close(); err != nil {
+	if err := mtree.apply(db.pendingLogEntry); err != nil {
 		return err
 	}
-
-	db.MultiTree = *mtree
-	// catch-up the pending changes
-	return db.MultiTree.apply(db.pendingLogEntry)
+	db.MultiTree.ReplaceWith(mtree)
+	return nil
 }
 
 // rewriteIfApplicable execute the snapshot rewrite strategy according to current height

--- a/sc/memiavl/db_test.go
+++ b/sc/memiavl/db_test.go
@@ -100,8 +100,9 @@ func TestRewriteSnapshotBackground(t *testing.T) {
 	require.NoError(t, err)
 
 	// spin up goroutine to keep querying the tree
+	stopped := false
 	go func() {
-		for {
+		for !stopped {
 			value := db.TreeByName("test").Get([]byte("hello1"))
 			require.True(t, value == nil || string(value) == "world1")
 		}
@@ -133,6 +134,7 @@ func TestRewriteSnapshotBackground(t *testing.T) {
 
 	// three files: snapshot, current link, rlog, LOCK
 	require.Equal(t, 4, len(entries))
+	stopped = true
 }
 
 func TestRlog(t *testing.T) {

--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -414,7 +414,7 @@ func (t *MultiTree) Close() error {
 	return errors.Join(errs...)
 }
 
-func (t *MultiTree) ReplaceWith(other *MultiTree) {
+func (t *MultiTree) ReplaceWith(other *MultiTree) error {
 	errs := make([]error, 0, len(t.trees))
 	for _, entry := range t.trees {
 		errs = append(errs, entry.Tree.ReplaceWith(other.TreeByName(entry.Name)))
@@ -422,6 +422,7 @@ func (t *MultiTree) ReplaceWith(other *MultiTree) {
 	t.treesByName = other.treesByName
 	t.lastCommitInfo = other.lastCommitInfo
 	t.metadata = other.metadata
+	return errors.Join(errs...)
 }
 
 func readMetadata(dir string) (*proto.MultiTreeMetadata, error) {

--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -414,6 +414,16 @@ func (t *MultiTree) Close() error {
 	return errors.Join(errs...)
 }
 
+func (t *MultiTree) ReplaceWith(other *MultiTree) {
+	errs := make([]error, 0, len(t.trees))
+	for _, entry := range t.trees {
+		errs = append(errs, entry.Tree.ReplaceWith(other.TreeByName(entry.Name)))
+	}
+	t.treesByName = other.treesByName
+	t.lastCommitInfo = other.lastCommitInfo
+	t.metadata = other.metadata
+}
+
 func readMetadata(dir string) (*proto.MultiTreeMetadata, error) {
 	// load commit info
 	bz, err := os.ReadFile(filepath.Join(dir, MetadataFileName))

--- a/sc/memiavl/tree.go
+++ b/sc/memiavl/tree.go
@@ -29,7 +29,7 @@ type Tree struct {
 	// when true, the get and iterator methods could return a slice pointing to mmaped blob files.
 	zeroCopy bool
 
-	// sync.RWMutex is used to protect the cache for thread safety
+	// sync.RWMutex is used to protect the tree for thread safety during snapshot reload
 	mtx *sync.RWMutex
 }
 
@@ -93,13 +93,12 @@ func (t *Tree) SetInitialVersion(initialVersion int64) error {
 
 // Copy returns a snapshot of the tree which won't be modified by further modifications on the main tree,
 // the returned new tree can be accessed concurrently with the main tree.
-func (t *Tree) Copy(cacheSize int) *Tree {
+func (t *Tree) Copy(_ int) *Tree {
 	if _, ok := t.root.(*MemNode); ok {
 		// protect the existing `MemNode`s from get modified in-place
 		t.cowVersion = t.version
 	}
 	newTree := *t
-	// cache is not copied along because it's not thread-safe to access
 	newTree.mtx = &sync.RWMutex{}
 	return &newTree
 }
@@ -116,6 +115,8 @@ func (t *Tree) ApplyChangeSet(changeSet iavl.ChangeSet) {
 }
 
 func (t *Tree) Set(key, value []byte) {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 	if value == nil {
 		// the value could be nil when replaying changes from write-ahead-log because of protobuf decoding
 		value = []byte{}
@@ -124,6 +125,8 @@ func (t *Tree) Set(key, value []byte) {
 }
 
 func (t *Tree) Remove(key []byte) {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 	_, t.root, _ = removeRecursive(t.root, key, t.version+1, t.cowVersion)
 }
 
@@ -157,6 +160,8 @@ func (t *Tree) RootHash() []byte {
 }
 
 func (t *Tree) GetWithIndex(key []byte) (int64, []byte) {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 	if t.root == nil {
 		return 0, nil
 	}
@@ -169,6 +174,8 @@ func (t *Tree) GetWithIndex(key []byte) (int64, []byte) {
 }
 
 func (t *Tree) GetByIndex(index int64) ([]byte, []byte) {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 	if index > math.MaxUint32 {
 		return nil, nil
 	}
@@ -195,12 +202,16 @@ func (t *Tree) Has(key []byte) bool {
 }
 
 func (t *Tree) Iterator(start, end []byte, ascending bool) dbm.Iterator {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 	return NewIterator(start, end, ascending, t.root, t.zeroCopy)
 }
 
 // ScanPostOrder scans the tree in post-order, and call the callback function on each node.
 // If the callback function returns false, the scan will be stopped.
 func (t *Tree) ScanPostOrder(callback func(node Node) bool) {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 	if t.root == nil {
 		return
 	}
@@ -248,6 +259,8 @@ func (t *Tree) Export() *Exporter {
 }
 
 func (t *Tree) Close() error {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	var err error
 	if t.snapshot != nil {
 		err = t.snapshot.Close()
@@ -255,6 +268,23 @@ func (t *Tree) Close() error {
 	}
 	t.root = nil
 	return err
+}
+
+// ReplaceWith is used during reload to replace the current tree with the newly loaded snapshot
+func (t *Tree) ReplaceWith(other *Tree) error {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	snapshot := t.snapshot
+	t.version = other.version
+	t.root = other.root
+	t.snapshot = other.snapshot
+	t.initialVersion = other.initialVersion
+	t.cowVersion = other.cowVersion
+	t.zeroCopy = other.zeroCopy
+	if snapshot != nil {
+		return snapshot.Close()
+	}
+	return nil
 }
 
 // nextVersionU32 is compatible with existing golang iavl implementation.


### PR DESCRIPTION
## Describe your changes and provide context
**Problem:**
In EVM, serving EVM RPC endpoints will have to query and access the latest state or historical state, when accessing latest state from MemIAVL, there's a race condition where the key we are trying to access doesn't exist because in the background, we have already switched to a difference snapshot after snapshot rewrite completes. Here's how it could happen:
1. Goroutine A: get a Tree pointer, preparing to call tree.Get
2. Goroutine B: reload snapshot and switched to a new tree, closed old tree
3. Goroutine A: Still use the old tree pointer to call get, got segmentation fault

And here's the error when this race condition is triggered:
<img width="1240" alt="image" src="https://github.com/sei-protocol/sei-db/assets/50607998/34432cf8-6e6f-4ebf-97b9-61b1ebacbd01">


**Solution:**
This PR address the issue by doing an internal replacement, instead of closing the old tree and create a new tree, we replace all the variables within each tree in a thread-safe manner as well as clean up and closing the old snapshots safely, this guarantees that all other operations will be block while we are replacing the whole tree.

## Testing performed to validate your change
Add Unit Test to repro and catch race conditions