### PR TITLE
Add command line tool to dump chain state size

### DIFF
--- a/tools/cmd/seidb/main.go
+++ b/tools/cmd/seidb/main.go
@@ -23,7 +23,8 @@ func main() {
 		benchmark.DBReverseIterationCmd(),
 		operations.DumpDbCmd(),
 		operations.PruneCmd(),
-		operations.DumpIAVLCmd())
+		operations.DumpIAVLCmd(),
+		operations.StateSizeCmd())
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/tools/cmd/seidb/operations/dump_db.go
+++ b/tools/cmd/seidb/operations/dump_db.go
@@ -18,7 +18,7 @@ func DumpDbCmd() *cobra.Command {
 	dumpDbCmd := &cobra.Command{
 		Use:   "dump-db",
 		Short: "For a given State Store DB, dump-db iterates over all keys and values for a specific store and writes them to a file",
-		Run:   dump,
+		Run:   executeDump,
 	}
 
 	dumpDbCmd.PersistentFlags().StringP("output-dir", "o", "", "Output Directory")
@@ -30,7 +30,7 @@ func DumpDbCmd() *cobra.Command {
 	return dumpDbCmd
 }
 
-func dump(cmd *cobra.Command, _ []string) {
+func executeDump(cmd *cobra.Command, _ []string) {
 	outputDir, _ := cmd.Flags().GetString("output-dir")
 	module, _ := cmd.Flags().GetString("module")
 	dbDir, _ := cmd.Flags().GetString("db-dir")

--- a/tools/cmd/seidb/operations/dump_db.go
+++ b/tools/cmd/seidb/operations/dump_db.go
@@ -18,7 +18,7 @@ func DumpDbCmd() *cobra.Command {
 	dumpDbCmd := &cobra.Command{
 		Use:   "dump-db",
 		Short: "For a given State Store DB, dump-db iterates over all keys and values for a specific store and writes them to a file",
-		Run:   executeDump,
+		Run:   executeDumpDB,
 	}
 
 	dumpDbCmd.PersistentFlags().StringP("output-dir", "o", "", "Output Directory")
@@ -30,7 +30,7 @@ func DumpDbCmd() *cobra.Command {
 	return dumpDbCmd
 }
 
-func executeDump(cmd *cobra.Command, _ []string) {
+func executeDumpDB(cmd *cobra.Command, _ []string) {
 	outputDir, _ := cmd.Flags().GetString("output-dir")
 	module, _ := cmd.Flags().GetString("module")
 	dbDir, _ := cmd.Flags().GetString("db-dir")

--- a/tools/cmd/seidb/operations/module.go
+++ b/tools/cmd/seidb/operations/module.go
@@ -1,0 +1,5 @@
+package operations
+
+var AllModules = []string{
+	"evm", "dex", "wasm", "aclaccesscontrol", "oracle", "epoch", "mint", "acc", "bank", "crisis", "feegrant", "staking", "distribution", "slashing", "gov", "params", "ibc", "upgrade", "evidence", "transfer", "tokenfactory",
+}

--- a/tools/cmd/seidb/operations/prune.go
+++ b/tools/cmd/seidb/operations/prune.go
@@ -13,7 +13,7 @@ func PruneCmd() *cobra.Command {
 	pruneDbCmd := &cobra.Command{
 		Use:   "prune",
 		Short: "Prune a db at a given height",
-		Run:   prune,
+		Run:   executePrune,
 	}
 
 	pruneDbCmd.PersistentFlags().StringP("db-dir", "d", "", "Database Directory")
@@ -23,7 +23,7 @@ func PruneCmd() *cobra.Command {
 	return pruneDbCmd
 }
 
-func prune(cmd *cobra.Command, _ []string) {
+func executePrune(cmd *cobra.Command, _ []string) {
 	dbDir, _ := cmd.Flags().GetString("db-dir")
 	dbBackend, _ := cmd.Flags().GetString("db-backend")
 	version, _ := cmd.Flags().GetInt64("version")

--- a/tools/cmd/seidb/operations/state_size.go
+++ b/tools/cmd/seidb/operations/state_size.go
@@ -5,36 +5,28 @@ import (
 
 	"github.com/sei-protocol/sei-db/common/logger"
 	"github.com/sei-protocol/sei-db/sc/memiavl"
-	"github.com/sei-protocol/sei-db/tools/utils"
 	"github.com/spf13/cobra"
 )
 
-func DumpIAVLCmd() *cobra.Command {
+func StateSizeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "dump-iavl",
-		Short: "Iterate and dump memIAVL data",
-		Run:   executeDumpIAVL,
+		Use:   "state-size",
+		Short: "Print analytical results for state size",
+		Run:   executeStateSize,
 	}
 
 	cmd.PersistentFlags().StringP("db-dir", "d", "", "Database Directory")
-	cmd.PersistentFlags().StringP("output-dir", "o", "", "Output Directory")
 	cmd.PersistentFlags().Int64("height", 0, "Block Height")
 	cmd.PersistentFlags().StringP("module", "m", "", "Module to export. Default to export all")
 	return cmd
 }
 
-func executeDumpIAVL(cmd *cobra.Command, _ []string) {
+func executeStateSize(cmd *cobra.Command, _ []string) {
 	module, _ := cmd.Flags().GetString("module")
 	dbDir, _ := cmd.Flags().GetString("db-dir")
-	outputDir, _ := cmd.Flags().GetString("output-dir")
 	height, _ := cmd.Flags().GetInt64("height")
-
 	if dbDir == "" {
 		panic("Must provide database dir")
-	}
-
-	if outputDir == "" {
-		panic("Must provide output dir")
 	}
 
 	opts := memiavl.Options{
@@ -47,14 +39,14 @@ func executeDumpIAVL(cmd *cobra.Command, _ []string) {
 		panic(err)
 	}
 	defer db.Close()
-	err = DumpIAVLData(module, db, outputDir)
+	err = PrintStateSize(module, db)
 	if err != nil {
 		panic(err)
 	}
 }
 
-// DumpIAVLData print the raw keys and values for given module at given height for memIAVL tree
-func DumpIAVLData(module string, db *memiavl.DB, outputDir string) error {
+// PrintStateSize print the raw keys and values for given module at given height for memIAVL tree
+func PrintStateSize(module string, db *memiavl.DB) error {
 	modules := []string{}
 	if module == "" {
 		modules = AllModules
@@ -64,29 +56,28 @@ func DumpIAVLData(module string, db *memiavl.DB, outputDir string) error {
 
 	for _, moduleName := range modules {
 		tree := db.TreeByName(moduleName)
+		totalNumKeys := 0
+		totalKeySize := 0
+		totalValueSize := 0
+		totalSize := 0
 		if tree == nil {
 			fmt.Printf("Tree does not exist for module %s \n", moduleName)
 		} else {
-			fmt.Printf("Dumping module: %s \n", moduleName)
-			currentFile, err := utils.CreateFile(outputDir, moduleName)
-			if err != nil {
-				return err
-			}
-			_, err = currentFile.WriteString(fmt.Sprintf("Tree %s has version %d and root hash: %X \n", moduleName, tree.Version(), tree.RootHash()))
-			if err != nil {
-				return nil
-			}
+			fmt.Printf("Calculating for module: %s \n", moduleName)
+			sizeByPrefix := map[string]int{}
 			tree.ScanPostOrder(func(node memiavl.Node) bool {
 				if node.IsLeaf() {
-					_, err := currentFile.WriteString(fmt.Sprintf("Key: %X, Value: %X \n", node.Key(), node.Value()))
-					if err != nil {
-						panic(err)
-					}
+					totalNumKeys++
+					totalKeySize += len(node.Key())
+					totalValueSize += len(node.Value())
+					totalSize += len(node.Key()) + len(node.Value())
+					prefix := string(node.Key()[:2])
+					sizeByPrefix[prefix] += len(node.Key()) + len(node.Value())
 				}
 				return true
 			})
-			currentFile.Close()
-			fmt.Printf("Finished dumping module: %s \n", moduleName)
+			fmt.Printf("Module %s total numKeys:%d, total keySize:%d, total valueSize:%d, totalSize: %d \n", moduleName, totalNumKeys, totalKeySize, totalValueSize, totalSize)
+			fmt.Printf("Module %s prefix breakdown: %v \n", moduleName, sizeByPrefix)
 		}
 	}
 	return nil

--- a/tools/cmd/seidb/operations/state_size.go
+++ b/tools/cmd/seidb/operations/state_size.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/sei-protocol/sei-db/common/logger"
@@ -71,13 +72,15 @@ func PrintStateSize(module string, db *memiavl.DB) error {
 					totalKeySize += len(node.Key())
 					totalValueSize += len(node.Value())
 					totalSize += len(node.Key()) + len(node.Value())
-					prefix := string(node.Key()[:2])
-					sizeByPrefix[prefix] += len(node.Key()) + len(node.Value())
+					prefix := fmt.Sprintf("%X", node.Key())
+					prefix = prefix[:2]
+					sizeByPrefix[prefix] += len(node.Value())
 				}
 				return true
 			})
 			fmt.Printf("Module %s total numKeys:%d, total keySize:%d, total valueSize:%d, totalSize: %d \n", moduleName, totalNumKeys, totalKeySize, totalValueSize, totalSize)
-			fmt.Printf("Module %s prefix breakdown: %v \n", moduleName, sizeByPrefix)
+			result, _ := json.MarshalIndent(sizeByPrefix, "", "  ")
+			fmt.Printf("Module %s prefix breakdown: %s \n", moduleName, result)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Describe your changes and provide context
This PR add a tool to dump a module size by prefix and also tells us total size.

## Testing performed to validate your change
Example output:

> root@ip-172-31-35-60:/home/ubuntu/sei-db/tools# seidb state-size -d ~/.sei/data/committer.db -m evm --height 82939158
> Calculating for module: evm 
> Module evm total numKeys:4446893, total keySize:103482401, total valueSize:1461642400, totalSize: 1565124801 
> Module evm prefix breakdown: {
>   "01": 1848008,
>   "02": 1847960,
>   "03": 3970464,
>   "07": 22294760,
>   "08": 83968,
>   "09": 20992,
>   "0A": 169064,
>   "0B": 1306833685,
>   "0D": 50665984,
>   "0E": 73859936,
>   "15": 12262,
>   "16": 16,
>   "17": 35301
> } 
