### PR TITLE
KeepLastVersion config for pruning

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,10 @@ type StateStoreConfig struct {
 	// ImportNumWorkers defines the number of goroutines used during import
 	// defaults to 1
 	ImportNumWorkers int `mapstructure:"import-num-workers"`
+
+	// Whether to keep last version of a key during pruning or delete
+	// defaults to true
+	KeepLastVersion bool `mapstructure:"keep-last-version"`
 }
 
 func DefaultStateCommitConfig() StateCommitConfig {

--- a/config/config.go
+++ b/config/config.go
@@ -102,5 +102,6 @@ func DefaultStateStoreConfig() StateStoreConfig {
 		KeepRecent:           DefaultSSKeepRecent,
 		PruneIntervalSeconds: DefaultSSPruneInterval,
 		ImportNumWorkers:     DefaultSSImportWorkers,
+		KeepLastVersion:      true,
 	}
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -66,4 +66,8 @@ ss-prune-interval = {{ .StateStore.PruneIntervalSeconds }}
 # defaults to 1
 ss-import-num-workers = {{ .StateStore.ImportNumWorkers }}
 
+# KeepLastVersion defines whether to keep last version of a key during pruning or delete
+# defaults to true
+ss-keep-last-version = {{ .StateStore.KeepLastVersion }}
+
 `

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -322,9 +322,10 @@ func (db *Database) Prune(version int64) error {
 			continue
 		}
 
-		// Delete a key if another entry for that key exists a larger version than original but leq to the prune height
+		// Delete a key if another entry for that key exists at a larger version than original but leq to the prune height
 		// Also delete a key if it has been tombstoned and its version is leq to the prune height
-		if prevVersionDecoded <= version && (bytes.Equal(prevKey, currKey) || valTombstoned(prevValEncoded)) {
+		// Also delete a key if KeepLastVersion is false and version is leq to the prune height
+		if prevVersionDecoded <= version && (bytes.Equal(prevKey, currKey) || valTombstoned(prevValEncoded) || !db.config.KeepLastVersion) {
 			err = batch.Delete(prevKeyEncoded, nil)
 			if err != nil {
 				return err

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -317,7 +317,7 @@ func (db *Database) Prune(version int64) error {
 		}
 
 		// Seek to next key if we are at a version which is higher than prune height
-		if currVersionDecoded > version {
+		if currVersionDecoded > version && (db.config.KeepLastVersion || prevVersionDecoded > version) {
 			itr.NextPrefix()
 			continue
 		}

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -317,6 +317,7 @@ func (db *Database) Prune(version int64) error {
 		}
 
 		// Seek to next key if we are at a version which is higher than prune height
+		// Do not seek to next key if KeepLastVersion is false and we need to delete the previous key in pruning
 		if currVersionDecoded > version && (db.config.KeepLastVersion || prevVersionDecoded > version) {
 			itr.NextPrefix()
 			continue

--- a/ss/pebbledb/db_test.go
+++ b/ss/pebbledb/db_test.go
@@ -11,9 +11,10 @@ import (
 
 func TestStorageTestSuite(t *testing.T) {
 	s := &sstest.StorageTestSuite{
-		NewDB: func(dir string) (types.StateStore, error) {
-			return New(dir, config.DefaultStateStoreConfig())
+		NewDB: func(dir string, config config.StateStoreConfig) (types.StateStore, error) {
+			return New(dir, config)
 		},
+		Config:         config.DefaultStateStoreConfig(),
 		EmptyBatchSize: 12,
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
- Introduce new state store config `KeepLastVersion` which dictates whether pruning should keep the latest version of a key or delete it

## Testing performed to validate your change
- Added unit tests
- Verifying on node
