### PR TITLE
Add Raw Import and Raw Batch for Writing to SS in any order of version

### DIFF
--- a/ss/pebbledb/batch.go
+++ b/ss/pebbledb/batch.go
@@ -65,3 +65,53 @@ func (b *Batch) Write() (err error) {
 
 	return b.batch.Commit(defaultWriteOpts)
 }
+
+// For writing kv pairs in any order of version
+type RawBatch struct {
+	storage *pebble.DB
+	batch   *pebble.Batch
+}
+
+func NewRawBatch(storage *pebble.DB) (*RawBatch, error) {
+	batch := storage.NewBatch()
+
+	return &RawBatch{
+		storage: storage,
+		batch:   batch,
+	}, nil
+}
+
+func (b *RawBatch) Size() int {
+	return b.batch.Len()
+}
+
+func (b *RawBatch) Reset() {
+	b.batch.Reset()
+}
+
+func (b *RawBatch) set(storeKey string, tombstone int64, key, value []byte, version int64) error {
+	prefixedKey := MVCCEncode(prependStoreKey(storeKey, key), version)
+	prefixedVal := MVCCEncode(value, tombstone)
+
+	if err := b.batch.Set(prefixedKey, prefixedVal, nil); err != nil {
+		return fmt.Errorf("failed to write PebbleDB batch: %w", err)
+	}
+
+	return nil
+}
+
+func (b *RawBatch) Set(storeKey string, key, value []byte, version int64) error {
+	return b.set(storeKey, 0, key, value, version)
+}
+
+func (b *RawBatch) Delete(storeKey string, key []byte, version int64) error {
+	return b.set(storeKey, version, key, []byte(tombstoneVal), version)
+}
+
+func (b *RawBatch) Write() (err error) {
+	defer func() {
+		err = errors.Join(err, b.batch.Close())
+	}()
+
+	return b.batch.Commit(defaultWriteOpts)
+}

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -507,6 +507,8 @@ func (db *Database) Import(version int64, ch <-chan types.SnapshotNode) error {
 
 	return db.RawImport(rawCh)
 
+	// TODO: Revert. This is just for testing RawImport End to End temporarily
+
 	// var wg sync.WaitGroup
 
 	// worker := func() {

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -1227,11 +1227,11 @@ func (s *StorageTestSuite) TestDatabaseRawImport() {
 	ch := make(chan types.RawSnapshotNode, 10)
 	var wg sync.WaitGroup
 
-	// Launch goroutine for each version
+	// Write versions in reverse order intentionally
 	for i := 10; i >= 0; i-- {
 		wg.Add(1)
 		go func(i int) {
-			defer wg.Done() // Decrement the counter when the goroutine completes
+			defer wg.Done()
 			ch <- types.RawSnapshotNode{
 				StoreKey: "store1",
 				Key:      []byte(fmt.Sprintf("key%03d", i)),
@@ -1246,7 +1246,6 @@ func (s *StorageTestSuite) TestDatabaseRawImport() {
 		close(ch)
 	}()
 
-	// Execute the import
 	s.Require().NoError(db.RawImport(ch))
 
 	for i := 0; i <= 10; i++ {

--- a/ss/types/store.go
+++ b/ss/types/store.go
@@ -30,6 +30,9 @@ type StateStore interface {
 	// Import the initial state of the store
 	Import(version int64, ch <-chan SnapshotNode) error
 
+	// Import the kv entries into the store in any order of version
+	RawImport(ch <-chan RawSnapshotNode) error
+
 	// Prune attempts to prune all versions up to and including the provided
 	// version argument. The operation should be idempotent. An error should be
 	// returned upon failure.
@@ -72,4 +75,20 @@ type SnapshotNode struct {
 	StoreKey string
 	Key      []byte
 	Value    []byte
+}
+
+type RawSnapshotNode struct {
+	StoreKey string
+	Key      []byte
+	Value    []byte
+	Version  int64
+}
+
+func GetRawSnapshotNode(node SnapshotNode, version int64) RawSnapshotNode {
+	return RawSnapshotNode{
+		StoreKey: node.StoreKey,
+		Key:      node.Key,
+		Value:    node.Value,
+		Version:  version,
+	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
- For archive node migration, adds `RawImport` and `RawBatch` which allows importing in kv entries in any order of version

## Testing performed to validate your change
- Added unit tests for both `RawImport` and `Import`
- Tested on node (re routed `Import` to use `RawImport`), verifying on new cluster

