### PR TITLE
Add a tool to replay changelog and repair missing entry in DB

### DIFF
--- a/tools/cmd/seidb/main.go
+++ b/tools/cmd/seidb/main.go
@@ -24,7 +24,8 @@ func main() {
 		operations.DumpDbCmd(),
 		operations.PruneCmd(),
 		operations.DumpIAVLCmd(),
-		operations.StateSizeCmd())
+		operations.StateSizeCmd(),
+		operations.ReplayChangelogCmd())
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -66,7 +66,9 @@ func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 	}
 
 	// close the database
-	ssStore.Close()
+	if ssStore != nil {
+		ssStore.Close()
+	}
 
 }
 

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -46,11 +46,11 @@ func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 }
 
 func processChangelogEntry(index uint64, entry proto.ChangelogEntry) error {
-	fmt.Printf("Index: %d, version: %d\n", index, entry.Version)
+	fmt.Printf("Offset: %d, Height: %d\n", index, entry.Version)
 	for _, store := range entry.Changesets {
 		storeName := store.Name
 		for _, kv := range store.Changeset.Pairs {
-			fmt.Printf("store: %s: key:%s\n", storeName, string(kv.Key))
+			fmt.Printf("store: %s, key: %X\n", storeName, kv.Key)
 		}
 	}
 	return nil

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -1,0 +1,57 @@
+package operations
+
+import (
+	"fmt"
+	"github.com/sei-protocol/sei-db/proto"
+	"github.com/sei-protocol/sei-db/stream/changelog"
+	"path/filepath"
+
+	"github.com/sei-protocol/sei-db/common/logger"
+	"github.com/spf13/cobra"
+)
+
+func ReplayChangelogCmd() *cobra.Command {
+	dumpDbCmd := &cobra.Command{
+		Use:   "replay-changelog",
+		Short: "Scan the changelog to replay and recover pebbledb data",
+		Run:   executeReplayChangelog,
+	}
+
+	dumpDbCmd.PersistentFlags().StringP("db-dir", "d", "", "Database Directory")
+	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 0, "From offset")
+	dumpDbCmd.PersistentFlags().Int64P("end-offset", "e", 1, "To offset")
+
+	return dumpDbCmd
+}
+
+func executeReplayChangelog(cmd *cobra.Command, _ []string) {
+	dbDir, _ := cmd.Flags().GetString("db-dir")
+	start, _ := cmd.Flags().GetInt64("start-offset")
+	end, _ := cmd.Flags().GetInt64("end-offset")
+	if dbDir == "" {
+		panic("Must provide database dir")
+	}
+	if start > end || start < 0 {
+		panic("Must provide a valid start/end offset")
+	}
+	logDir := filepath.Join(dbDir, "changelog")
+	stream, err := changelog.NewStream(logger.NewNopLogger(), logDir, changelog.Config{})
+	if err != nil {
+		panic(err)
+	}
+	err = stream.Replay(uint64(start), uint64(end), processChangelogEntry)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func processChangelogEntry(index uint64, entry proto.ChangelogEntry) error {
+	fmt.Printf("Index: %d, version: %d\n", index, entry.Version)
+	for _, store := range entry.Changesets {
+		storeName := store.Name
+		for _, kv := range store.Changeset.Pairs {
+			fmt.Printf("store: %s: key:%s\n", storeName, string(kv.Key))
+		}
+	}
+	return nil
+}

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -48,7 +48,7 @@ func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 		panic(err)
 	}
 
-	// open the database if apply is true
+	// open the database if this is not a dry run
 	if noDryRun {
 		ssConfig := config.DefaultStateStoreConfig()
 		ssConfig.KeepRecent = 0

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -26,12 +26,12 @@ func ReplayChangelogCmd() *cobra.Command {
 
 func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 	dbDir, _ := cmd.Flags().GetString("db-dir")
-	start, _ := cmd.Flags().GetInt64("start-height")
-	end, _ := cmd.Flags().GetInt64("end-height")
+	startHeight, _ := cmd.Flags().GetInt64("start-height")
+	endHeight, _ := cmd.Flags().GetInt64("end-height")
 	if dbDir == "" {
 		panic("Must provide database dir")
 	}
-	if start > end || start < 0 {
+	if startHeight > endHeight || startHeight < 0 {
 		panic("Must provide a valid start/end offset")
 	}
 	logDir := filepath.Join(dbDir, "changelog")
@@ -49,8 +49,10 @@ func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 		panic(err)
 	}
 	gap := firstEntry.Version - int64(firstOffset)
-
-	err = stream.Replay(uint64(start-gap), uint64(end-gap), processChangelogEntry)
+	startOffset := uint64(startHeight - gap)
+	endOffset := uint64(endHeight - gap)
+	fmt.Printf("Replaying changelog from offset %d to %d\n", startOffset, endOffset)
+	err = stream.Replay(startOffset, endOffset, processChangelogEntry)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Describe your changes and provide context
This PR introduce a new seidb command to replay changelog, at the same time we can choose to reapply the changelog to DB if we want to recover any missing data

## Testing performed to validate your change
Tested on snapshotter node