### PR TITLE
Fix changelog recover failure due to wrong path

### DIFF
--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -117,13 +117,17 @@ func New(dataDir string, config config.StateStoreConfig) (*Database, error) {
 		pendingChanges:  make(chan VersionedChangesets, config.AsyncWriteBuffer),
 	}
 	if config.DedicatedChangelog {
+		keepRecent := config.KeepRecent
+		if config.KeepRecent <= 0 {
+			keepRecent = 100000
+		}
 		streamHandler, _ := changelog.NewStream(
 			logger.NewNopLogger(),
 			utils.GetChangelogPath(dataDir),
 			changelog.Config{
 				DisableFsync:  true,
 				ZeroCopy:      true,
-				KeepRecent:    uint64(config.KeepRecent),
+				KeepRecent:    uint64(keepRecent),
 				PruneInterval: 300 * time.Second,
 			},
 		)

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -117,17 +117,13 @@ func New(dataDir string, config config.StateStoreConfig) (*Database, error) {
 		pendingChanges:  make(chan VersionedChangesets, config.AsyncWriteBuffer),
 	}
 	if config.DedicatedChangelog {
-		keepRecent := config.KeepRecent
-		if config.KeepRecent <= 0 {
-			keepRecent = 100000
-		}
 		streamHandler, _ := changelog.NewStream(
 			logger.NewNopLogger(),
 			utils.GetChangelogPath(dataDir),
 			changelog.Config{
 				DisableFsync:  true,
 				ZeroCopy:      true,
-				KeepRecent:    uint64(keepRecent),
+				KeepRecent:    uint64(config.KeepRecent),
 				PruneInterval: 300 * time.Second,
 			},
 		)

--- a/ss/rocksdb/db.go
+++ b/ss/rocksdb/db.go
@@ -374,3 +374,6 @@ func cloneAppend(bz []byte, tail []byte) (res []byte) {
 	copy(res[len(bz):], tail)
 	return
 }
+func (db *Database) RawImport(ch <-chan types.RawSnapshotNode) error {
+	panic("implement me")
+}

--- a/ss/rocksdb_init.go
+++ b/ss/rocksdb_init.go
@@ -12,11 +12,11 @@ import (
 
 func init() {
 	initializer := func(dir string, configs config.StateStoreConfig) (types.StateStore, error) {
-		dbHome := dir
+		dbHome := utils.GetStateStorePath(dir, configs.Backend)
 		if configs.DBDirectory != "" {
 			dbHome = configs.DBDirectory
 		}
-		return rocksdb.New(utils.GetStateStorePath(dbHome, configs.Backend), configs)
+		return rocksdb.New(dbHome, configs)
 	}
 	RegisterBackend(RocksDBBackend, initializer)
 }

--- a/ss/sqlite/db.go
+++ b/ss/sqlite/db.go
@@ -334,3 +334,7 @@ func execPragmas(db *sql.DB, pragmas []string) error {
 	}
 	return nil
 }
+
+func (db *Database) RawImport(ch <-chan types.RawSnapshotNode) error {
+	panic("implement me")
+}

--- a/ss/sqlite_init.go
+++ b/ss/sqlite_init.go
@@ -12,11 +12,11 @@ import (
 
 func init() {
 	initializer := func(dir string, configs config.StateStoreConfig) (types.StateStore, error) {
-		dbHome := dir
+		dbHome := utils.GetStateStorePath(dir, configs.Backend)
 		if configs.DBDirectory != "" {
 			dbHome = configs.DBDirectory
 		}
-		return sqlite.New(utils.GetStateStorePath(dbHome, configs.Backend), configs)
+		return sqlite.New(dbHome, configs)
 	}
 	RegisterBackend(SQLiteBackend, initializer)
 }

--- a/ss/store.go
+++ b/ss/store.go
@@ -47,6 +47,9 @@ func NewStateStore(logger logger.Logger, homeDir string, ssConfig config.StateSt
 	// Handle auto recovery for DB running with async mode
 	if ssConfig.DedicatedChangelog {
 		changelogPath := utils.GetChangelogPath(utils.GetStateStorePath(homeDir, ssConfig.Backend))
+		if ssConfig.DBDirectory != "" {
+			changelogPath = utils.GetChangelogPath(ssConfig.DBDirectory)
+		}
 		err := RecoverStateStore(logger, changelogPath, stateStore)
 		if err != nil {
 			return nil, err
@@ -61,6 +64,7 @@ func NewStateStore(logger logger.Logger, homeDir string, ssConfig config.StateSt
 // RecoverStateStore will be called during initialization to recover the state from rlog
 func RecoverStateStore(logger logger.Logger, changelogPath string, stateStore types.StateStore) error {
 	ssLatestVersion, err := stateStore.GetLatestVersion()
+	logger.Info(fmt.Sprintf("Recovering from changelog %s at latest SS version %d", changelogPath, ssLatestVersion))
 	if err != nil {
 		return err
 	}

--- a/ss/store_test.go
+++ b/ss/store_test.go
@@ -17,12 +17,12 @@ func TestNewStateStore(t *testing.T) {
 	ssConfig := config.StateStoreConfig{
 		DedicatedChangelog: true,
 		Backend:            string(PebbleDBBackend),
-		AsyncWriteBuffer:   10,
-		KeepRecent:         100,
+		AsyncWriteBuffer:   50,
+		KeepRecent:         500,
 	}
 	stateStore, err := NewStateStore(logger.NewNopLogger(), tempDir, ssConfig)
 	require.NoError(t, err)
-	for i := 1; i < 10; i++ {
+	for i := 1; i < 20; i++ {
 		var changesets []*proto.NamedChangeSet
 		kvPair := &iavl.KVPair{
 			Delete: false,
@@ -49,7 +49,7 @@ func TestNewStateStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure key and values can be found
-	for i := 1; i < 10; i++ {
+	for i := 1; i < 20; i++ {
 		value, err := stateStore.Get("storeA", int64(i), []byte(fmt.Sprintf("key%d", i)))
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("value%d", i), string(value))

--- a/ss/store_test.go
+++ b/ss/store_test.go
@@ -3,6 +3,7 @@ package ss
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cosmos/iavl"
@@ -14,13 +15,14 @@ import (
 
 func TestNewStateStore(t *testing.T) {
 	tempDir := os.TempDir()
+	homeDir := filepath.Join(tempDir, "seidb")
 	ssConfig := config.StateStoreConfig{
 		DedicatedChangelog: true,
 		Backend:            string(PebbleDBBackend),
 		AsyncWriteBuffer:   50,
 		KeepRecent:         500,
 	}
-	stateStore, err := NewStateStore(logger.NewNopLogger(), tempDir, ssConfig)
+	stateStore, err := NewStateStore(logger.NewNopLogger(), homeDir, ssConfig)
 	require.NoError(t, err)
 	for i := 1; i < 20; i++ {
 		var changesets []*proto.NamedChangeSet
@@ -45,7 +47,7 @@ func TestNewStateStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reopen a new state store
-	stateStore, err = NewStateStore(logger.NewNopLogger(), tempDir, ssConfig)
+	stateStore, err = NewStateStore(logger.NewNopLogger(), homeDir, ssConfig)
 	require.NoError(t, err)
 
 	// Make sure key and values can be found


### PR DESCRIPTION
## Describe your changes and provide context
The changelog path could be wrong if someone overwrite the DB directory, which could lead to failure of recovery during ss restart.


## Testing performed to validate your change
Tested on RPC node and make sure receipts are recovered everytime after seid crash
