### PR TITLE
fix: init app earliest version correctly after state sync

### DIFF
--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -177,11 +177,14 @@ func (db *Database) GetLatestVersion() (int64, error) {
 }
 
 func (db *Database) SetEarliestVersion(version int64) error {
-	db.earliestVersion = version
+	if version > db.earliestVersion {
+		db.earliestVersion = version
 
-	var ts [VersionSize]byte
-	binary.LittleEndian.PutUint64(ts[:], uint64(version))
-	return db.storage.Set([]byte(earliestVersionKey), ts[:], defaultWriteOpts)
+		var ts [VersionSize]byte
+		binary.LittleEndian.PutUint64(ts[:], uint64(version))
+		return db.storage.Set([]byte(earliestVersionKey), ts[:], defaultWriteOpts)
+	}
+	return nil
 }
 
 func (db *Database) GetEarliestVersion() (int64, error) {


### PR DESCRIPTION
## Describe your changes and provide context
init app earliest version correctly after state sync to avoid app earliest version < block earliest version
## Testing performed to validate your change

