### PR TITLE
Enhance replay chagnelog tool to replay till the end

### DIFF
--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -14,6 +14,7 @@ import (
 )
 
 var ssStore types.StateStore
+var dryRun bool = true
 
 func ReplayChangelogCmd() *cobra.Command {
 	dumpDbCmd := &cobra.Command{
@@ -23,8 +24,8 @@ func ReplayChangelogCmd() *cobra.Command {
 	}
 
 	dumpDbCmd.PersistentFlags().StringP("db-dir", "d", "", "Database Directory")
-	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 0, "From offset")
-	dumpDbCmd.PersistentFlags().Int64P("end-offset", "e", 1, "End offset")
+	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 1, "From offset")
+	dumpDbCmd.PersistentFlags().Int64P("end-offset", "e", 0, "End offset, default is latest")
 	dumpDbCmd.PersistentFlags().Bool("no-dry-run", false, "Whether to dry run or re-apply the changelog to DB")
 
 	return dumpDbCmd
@@ -32,24 +33,30 @@ func ReplayChangelogCmd() *cobra.Command {
 
 func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 	dbDir, _ := cmd.Flags().GetString("db-dir")
-	start, _ := cmd.Flags().GetInt64("start-offset")
-	end, _ := cmd.Flags().GetInt64("end-offset")
+	start, _ := cmd.Flags().GetUint64("start-offset")
+	end, _ := cmd.Flags().GetUint64("end-offset")
 	noDryRun, _ := cmd.Flags().GetBool("no-dry-run")
 	if dbDir == "" {
 		panic("Must provide database dir")
 	}
 
-	if start > end || start < 0 {
-		panic("Must provide a valid start/end offset")
-	}
 	logDir := filepath.Join(dbDir, "changelog")
 	stream, err := changelog.NewStream(logger.NewNopLogger(), logDir, changelog.Config{})
 	if err != nil {
 		panic(err)
 	}
+	if end <= 0 {
+		// use latest offset
+		endOffset, err := stream.LastOffset()
+		if err != nil {
+			panic(err)
+		}
+		end = endOffset
+	}
 
 	// open the database if this is not a dry run
 	if noDryRun {
+		dryRun = false
 		ssConfig := config.DefaultStateStoreConfig()
 		ssConfig.KeepRecent = 0
 		ssConfig.DBDirectory = dbDir
@@ -60,7 +67,7 @@ func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 	}
 
 	// replay the changelog
-	err = stream.Replay(uint64(start), uint64(end), processChangelogEntry)
+	err = stream.Replay(start, end, processChangelogEntry)
 	if err != nil {
 		panic(err)
 	}
@@ -77,7 +84,9 @@ func processChangelogEntry(index uint64, entry proto.ChangelogEntry) error {
 	for _, changeset := range entry.Changesets {
 		storeName := changeset.Name
 		for _, kv := range changeset.Changeset.Pairs {
-			fmt.Printf("store: %s, key: %X\n", storeName, kv.Key)
+			if dryRun {
+				fmt.Printf("store: %s, key: %X\n", storeName, kv.Key)
+			}
 		}
 		if ssStore != nil {
 			fmt.Printf("Re-applied changeset for height %d\n", entry.Version)

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -24,7 +24,7 @@ func ReplayChangelogCmd() *cobra.Command {
 	}
 
 	dumpDbCmd.PersistentFlags().StringP("db-dir", "d", "", "Database Directory")
-	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 1, "From offset")
+	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 0, "From offset")
 	dumpDbCmd.PersistentFlags().Int64P("end-offset", "e", 0, "End offset, default is latest")
 	dumpDbCmd.PersistentFlags().Bool("no-dry-run", false, "Whether to dry run or re-apply the changelog to DB")
 
@@ -45,6 +45,16 @@ func executeReplayChangelog(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		panic(err)
 	}
+
+	// use first available offset
+	if start <= 0 {
+		startOffset, err := stream.FirstOffset()
+		if err != nil {
+			panic(err)
+		}
+		start = startOffset
+	}
+
 	if end <= 0 {
 		// use latest offset
 		endOffset, err := stream.LastOffset()

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -14,7 +14,7 @@ import (
 )
 
 var ssStore types.StateStore
-var dryRun bool = true
+var dryRun = true
 
 func ReplayChangelogCmd() *cobra.Command {
 	dumpDbCmd := &cobra.Command{

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -24,8 +24,8 @@ func ReplayChangelogCmd() *cobra.Command {
 	}
 
 	dumpDbCmd.PersistentFlags().StringP("db-dir", "d", "", "Database Directory")
-	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 0, "From offset")
-	dumpDbCmd.PersistentFlags().Int64P("end-offset", "e", 0, "End offset, default is latest")
+	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 0, "From offset, default to earliest offset")
+	dumpDbCmd.PersistentFlags().Int64P("end-offset", "e", 0, "End offset, default to latest offset")
 	dumpDbCmd.PersistentFlags().Bool("no-dry-run", false, "Whether to dry run or re-apply the changelog to DB")
 
 	return dumpDbCmd

--- a/tools/cmd/seidb/operations/replay_changelog.go
+++ b/tools/cmd/seidb/operations/replay_changelog.go
@@ -24,7 +24,7 @@ func ReplayChangelogCmd() *cobra.Command {
 	}
 
 	dumpDbCmd.PersistentFlags().StringP("db-dir", "d", "", "Database Directory")
-	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 0, "From offset, default to earliest offset")
+	dumpDbCmd.PersistentFlags().Int64P("start-offset", "s", 0, "Start offset, default to earliest offset")
 	dumpDbCmd.PersistentFlags().Int64P("end-offset", "e", 0, "End offset, default to latest offset")
 	dumpDbCmd.PersistentFlags().Bool("no-dry-run", false, "Whether to dry run or re-apply the changelog to DB")
 


### PR DESCRIPTION
## Describe your changes and provide context
This PR add default offset to the replay tool so that it will default to run from index 1 to the latest changelog index.
## Testing performed to validate your change

