### PR TITLE
Set Earliest Version Ignore Version

### DIFF
--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -181,8 +181,8 @@ func (db *Database) GetLatestVersion() (int64, error) {
 	return int64(binary.LittleEndian.Uint64(bz)), closer.Close()
 }
 
-func (db *Database) SetEarliestVersion(version int64) error {
-	if version > db.earliestVersion {
+func (db *Database) SetEarliestVersion(version int64, ignoreVersion bool) error {
+	if version > db.earliestVersion || ignoreVersion {
 		db.earliestVersion = version
 
 		var ts [VersionSize]byte
@@ -486,7 +486,7 @@ func (db *Database) Prune(version int64) error {
 		}
 	}
 
-	return db.SetEarliestVersion(earliestVersion)
+	return db.SetEarliestVersion(earliestVersion, false)
 }
 
 func (db *Database) Iterator(storeKey string, version int64, start, end []byte) (types.DBIterator, error) {

--- a/ss/rocksdb/db.go
+++ b/ss/rocksdb/db.go
@@ -127,7 +127,7 @@ func (db *Database) GetLatestVersion() (int64, error) {
 	return int64(binary.LittleEndian.Uint64(bz)), nil
 }
 
-func (db *Database) SetEarliestVersion(version int64) error {
+func (db *Database) SetEarliestVersion(version int64, ignoreVersion bool) error {
 	panic("not implemented")
 }
 

--- a/ss/sqlite/db.go
+++ b/ss/sqlite/db.go
@@ -142,7 +142,7 @@ func (db *Database) GetEarliestVersion() (int64, error) {
 	panic("not implemented")
 }
 
-func (db *Database) SetEarliestVersion(version int64) error {
+func (db *Database) SetEarliestVersion(version int64, ignoreVersion bool) error {
 	panic("not implemented")
 }
 

--- a/ss/types/store.go
+++ b/ss/types/store.go
@@ -17,7 +17,7 @@ type StateStore interface {
 	GetLatestVersion() (int64, error)
 	SetLatestVersion(version int64) error
 	GetEarliestVersion() (int64, error)
-	SetEarliestVersion(version int64) error
+	SetEarliestVersion(version int64, ignoreVersion bool) error
 	GetLatestMigratedKey() ([]byte, error)
 	SetLatestMigratedKey(key []byte) error
 	GetLatestMigratedModule() (string, error)


### PR DESCRIPTION
## Describe your changes and provide context
- Add new flag in set earliest version to ignoreVersion in cases like migration where we set earliest version to a height less than what was previously there

## Testing performed to validate your change
- Verified on node 