### PR TITLE
Improve SeiDB replay&restart time by 2x

### DIFF
--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -355,7 +355,7 @@ func (t *MultiTree) Catchup(stream types.Stream[proto.ChangelogEntry], endVersio
 		}
 		for _, tree := range t.trees {
 			if _, found := updatedTrees[tree.Name]; !found {
-				tree.SaveVersion(false)
+				tree.ApplyChangeSetAsync(iavl.ChangeSet{})
 			}
 		}
 		t.lastCommitInfo.Version = utils.NextVersion(t.lastCommitInfo.Version, t.initialVersion)

--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -351,9 +351,7 @@ func (t *MultiTree) Catchup(stream types.Stream[proto.ChangelogEntry], endVersio
 			treeName := cs.Name
 			t.TreeByName(treeName).ApplyChangeSetAsync(cs.Changeset)
 		}
-		if _, err := t.SaveVersion(false); err != nil {
-			return fmt.Errorf("replay changeset failed to save version, %w", err)
-		}
+		t.lastCommitInfo.Version = utils.NextVersion(t.lastCommitInfo.Version, t.initialVersion)
 		replayCount++
 		if replayCount%1000 == 0 {
 			fmt.Printf("Replayed %d changelog entries\n", replayCount)
@@ -368,7 +366,7 @@ func (t *MultiTree) Catchup(stream types.Stream[proto.ChangelogEntry], endVersio
 	if err != nil {
 		return err
 	}
-
+	t.lastCommitInfo.StoreInfos = []proto.StoreInfo{}
 	t.UpdateCommitInfo()
 	return nil
 }

--- a/sc/memiavl/multitree.go
+++ b/sc/memiavl/multitree.go
@@ -349,9 +349,11 @@ func (t *MultiTree) Catchup(stream types.Stream[proto.ChangelogEntry], endVersio
 		}
 		for _, cs := range entry.Changesets {
 			treeName := cs.Name
+			fmt.Printf("[Debug] Changeset for version %d and tree %s\n", index, treeName)
 			t.TreeByName(treeName).ApplyChangeSetAsync(cs.Changeset)
 		}
 		t.lastCommitInfo.Version = utils.NextVersion(t.lastCommitInfo.Version, t.initialVersion)
+		t.lastCommitInfo.StoreInfos = []proto.StoreInfo{}
 		replayCount++
 		if replayCount%1000 == 0 {
 			fmt.Printf("Replayed %d changelog entries\n", replayCount)
@@ -366,7 +368,6 @@ func (t *MultiTree) Catchup(stream types.Stream[proto.ChangelogEntry], endVersio
 	if err != nil {
 		return err
 	}
-	t.lastCommitInfo.StoreInfos = []proto.StoreInfo{}
 	t.UpdateCommitInfo()
 	return nil
 }

--- a/sc/memiavl/tree.go
+++ b/sc/memiavl/tree.go
@@ -132,6 +132,7 @@ func (t *Tree) StartBackgroundWrite() {
 		defer t.pendingWg.Done()
 		for nextChange := range t.pendingChanges {
 			t.ApplyChangeSet(nextChange)
+			t.SaveVersion(false)
 		}
 	}()
 }

--- a/sc/memiavl/tree.go
+++ b/sc/memiavl/tree.go
@@ -17,7 +17,7 @@ import (
 var _ types.Tree = (*Tree)(nil)
 var emptyHash = sha256.New().Sum(nil)
 
-// verify change sets by replay them to rebuild iavl tree and verify the root hashes
+// Tree verify change sets by replay them to rebuild iavl tree and verify the root hashes
 type Tree struct {
 	version uint32
 	// root node of empty tree is represented as `nil`
@@ -31,6 +31,9 @@ type Tree struct {
 
 	// sync.RWMutex is used to protect the tree for thread safety during snapshot reload
 	mtx *sync.RWMutex
+
+	pendingChanges chan iavl.ChangeSet
+	pendingWg      sync.WaitGroup
 }
 
 // NewEmptyTree creates an empty tree at an arbitrary version.
@@ -43,8 +46,9 @@ func NewEmptyTree(version uint64, initialVersion uint32) *Tree {
 		version:        uint32(version),
 		initialVersion: initialVersion,
 		// no need to copy if the tree is not backed by snapshot
-		zeroCopy: true,
-		mtx:      &sync.RWMutex{},
+		zeroCopy:  true,
+		mtx:       &sync.RWMutex{},
+		pendingWg: sync.WaitGroup{},
 	}
 }
 
@@ -62,10 +66,11 @@ func NewWithInitialVersion(initialVersion uint32) *Tree {
 // NewFromSnapshot mmap the blob files and create the root node.
 func NewFromSnapshot(snapshot *Snapshot, zeroCopy bool, _ int) *Tree {
 	tree := &Tree{
-		version:  snapshot.Version(),
-		snapshot: snapshot,
-		zeroCopy: zeroCopy,
-		mtx:      &sync.RWMutex{},
+		version:   snapshot.Version(),
+		snapshot:  snapshot,
+		zeroCopy:  zeroCopy,
+		mtx:       &sync.RWMutex{},
+		pendingWg: sync.WaitGroup{},
 	}
 
 	if !snapshot.IsEmpty() {
@@ -114,6 +119,27 @@ func (t *Tree) ApplyChangeSet(changeSet iavl.ChangeSet) {
 			t.Set(pair.Key, pair.Value)
 		}
 	}
+}
+
+func (t *Tree) ApplyChangeSetAsync(changeSet iavl.ChangeSet) {
+	t.pendingChanges <- changeSet
+}
+
+func (t *Tree) StartBackgroundWrite() {
+	t.pendingWg.Add(1)
+	t.pendingChanges = make(chan iavl.ChangeSet, 1000)
+	go func() {
+		defer t.pendingWg.Done()
+		for nextChange := range t.pendingChanges {
+			t.ApplyChangeSet(nextChange)
+		}
+	}()
+}
+
+func (t *Tree) WaitToCompleteAsyncWrite() {
+	close(t.pendingChanges)
+	t.pendingWg.Wait()
+	t.pendingChanges = nil
 }
 
 func (t *Tree) Set(key, value []byte) {
@@ -269,6 +295,9 @@ func (t *Tree) Close() error {
 	if t.snapshot != nil {
 		err = t.snapshot.Close()
 		t.snapshot = nil
+	}
+	if t.pendingChanges != nil {
+		close(t.pendingChanges)
 	}
 	t.root = nil
 	return err


### PR DESCRIPTION
## Describe your changes and provide context
Add parallelization for replaying changelog during restart.

## Testing performed to validate your change
Before this change:
```
Jan 07 11:13:43 ip-172-31-9-162 seid[38481]: 11:13AM INF Start catching up and replaying the MemIAVL changelog file
Jan 07 11:26:20 ip-172-31-9-162 seid[38481]: 11:26AM INF Finished the replay and caught up to version 0
```


After this change:
```
Jan 07 11:14:49 ip-172-31-2-59 seid[39128]: 11:14AM INF Start catching up and replaying the MemIAVL changelog file
Jan 07 11:21:57 ip-172-31-2-59 seid[39128]: 11:21AM INF Finished the replay and caught up to version 0
```


