### PR TITLE
fix: open wal SIGSEGV

### DIFF
--- a/stream/changelog/changelog.go
+++ b/stream/changelog/changelog.go
@@ -231,6 +231,10 @@ func (stream *Stream) Close() error {
 
 // open opens the replay log, try to truncate the corrupted tail if there's any
 func open(dir string, opts *wal.Options) (*wal.Log, error) {
+	// if opts is nil, use the default options
+	if opts == nil {
+		opts = &wal.Options{}
+	}
 	rlog, err := wal.Open(dir, opts)
 	if errors.Is(err, wal.ErrCorrupt) {
 		// try to truncate corrupted tail

--- a/stream/changelog/changelog.go
+++ b/stream/changelog/changelog.go
@@ -252,7 +252,7 @@ func open(dir string, opts *wal.Options) (*wal.Log, error) {
 		}
 
 		if len(lastSeg) == 0 {
-			return nil, err
+			return nil, fmt.Errorf("no valid segments in %s: %w", dir, err)
 		}
 		if err = truncateCorruptedTail(filepath.Join(dir, lastSeg), opts.LogFormat); err != nil {
 			return nil, fmt.Errorf("truncate corrupted tail fail: %w", err)


### PR DESCRIPTION
## Describe your changes and provide context
- When wal.Open() encounters an error, it is designed to call truncateCorruptedTail() to truncate the corrupted tail.
- However, changelog.GetLastIndex() passes a nil parameter when calling the func open `rlog, err := open(dir, nil)`.
- As a result, open(dir, nil) passes the second parameter to truncateCorruptedTail(), which is nil, leading to a nil pointer dereference (SIGSEGV) and an appHash mismatch error.
## Testing performed to validate your change

