### PR TITLE
Add Upper Bound ReverseIterator

### DIFF
--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -662,6 +662,8 @@ func (db *Database) Iterator(storeKey string, version int64, start, end []byte) 
 	return newPebbleDBIterator(itr, storePrefix(storeKey), start, end, version, db.earliestVersion, false), nil
 }
 
+// Taken from pebbledb prefix upper bound
+// Returns smallest key strictly greater than the prefix
 func prefixEnd(b []byte) []byte {
 	end := make([]byte, len(b))
 	copy(end, b)


### PR DESCRIPTION
## Describe your changes and provide context
- Fix to bug in `ReverseIterate` when upper bound is `nil` and seeks to a key which is not in the current store and immediately invalidates
- Update upper bound, seek to latest possible key in a store 


## Testing performed to validate your change
- Added unit test, verifying on node
