### PR TITLE
Add config for to OnlyAllowExportOnSnapshotVersion

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,10 @@ type StateCommitConfig struct {
 	// CacheSize defines the size of the cache for each memiavl store.
 	// Deprecated: this is removed, we will just rely on mmap page cache
 	CacheSize int `mapstructure:"cache-size"`
+
+	// OnlyAllowExportOnSnapshotVersion defines whether we only allow state sync
+	// snapshot creation happens after the memiavl snapshot is created
+	OnlyAllowExportOnSnapshotVersion bool `mapstructure:"only-allow-export-on-snapshot-version"`
 }
 
 type StateStoreConfig struct {

--- a/config/toml.go
+++ b/config/toml.go
@@ -32,6 +32,10 @@ sc-snapshot-interval = {{ .StateCommit.SnapshotInterval }}
 # SnapshotWriterLimit defines the max concurrency for taking commit store snapshot
 sc-snapshot-writer-limit = {{ .StateCommit.SnapshotWriterLimit }}
 
+# OnlyAllowExportOnSnapshotVersion defines whether we only allow state sync
+# snapshot creation happens after the memiavl snapshot is created.
+sc-only-allow-export-on-snapshot-version = {{ .StateCommit.OnlyAllowExportOnSnapshotVersion }}
+
 [state-store]
 # Enable defines whether the state-store should be enabled for storing historical data.
 # Supporting historical queries or exporting state snapshot requires setting this to true

--- a/sc/memiavl/export.go
+++ b/sc/memiavl/export.go
@@ -26,12 +26,12 @@ type MultiTreeExporter struct {
 	exporter *Exporter
 }
 
-func NewMultiTreeExporter(dir string, version uint32, supportExportNonSnapshotVersion bool) (exporter *MultiTreeExporter, err error) {
+func NewMultiTreeExporter(dir string, version uint32, onlyAllowExportOnSnapshotVersion bool) (exporter *MultiTreeExporter, err error) {
 	var (
 		db    *DB
 		mtree *MultiTree
 	)
-	if supportExportNonSnapshotVersion {
+	if !onlyAllowExportOnSnapshotVersion {
 		db, err = OpenDB(logger.NewNopLogger(), int64(version), Options{
 			Dir:                 dir,
 			ZeroCopy:            true,
@@ -47,11 +47,11 @@ func NewMultiTreeExporter(dir string, version uint32, supportExportNonSnapshotVe
 			return nil, fmt.Errorf("failed to load current version: %w", err)
 		}
 		if int64(version) > curVersion {
-			return nil, fmt.Errorf("snapshot is not created yet: height: %d", version)
+			return nil, fmt.Errorf("export skipped because memiavl snapshot is not created yet for height: %d", version)
 		}
 		mtree, err = LoadMultiTree(filepath.Join(dir, snapshotName(int64(version))), true, 0)
 		if err != nil {
-			return nil, fmt.Errorf("snapshot don't exists: height: %d, %w", version, err)
+			return nil, fmt.Errorf("memiavl snapshot don't exist for height: %d, %w", version, err)
 		}
 	}
 

--- a/sc/memiavl/opts.go
+++ b/sc/memiavl/opts.go
@@ -29,6 +29,10 @@ type Options struct {
 	// it do nothing if the target version is `0`.
 	LoadForOverwriting bool
 
+	// OnlyAllowExportOnSnapshotVersion defines whether the state sync exporter should only export the
+	// version that matches wit the current memiavl snapshot version
+	OnlyAllowExportOnSnapshotVersion bool
+
 	// Limit the number of concurrent snapshot writers
 	SnapshotWriterLimit int
 }

--- a/sc/memiavl/snapshot_test.go
+++ b/sc/memiavl/snapshot_test.go
@@ -169,7 +169,7 @@ func TestDBSnapshotRestore(t *testing.T) {
 }
 
 func testSnapshotRoundTrip(t *testing.T, db *DB) {
-	exporter, err := NewMultiTreeExporter(db.dir, uint32(db.Version()), true)
+	exporter, err := NewMultiTreeExporter(db.dir, uint32(db.Version()), false)
 	require.NoError(t, err)
 
 	restoreDir := t.TempDir()

--- a/sc/store.go
+++ b/sc/store.go
@@ -25,14 +25,15 @@ func NewCommitStore(homeDir string, logger logger.Logger, config config.StateCom
 		scDir = config.Directory
 	}
 	opts := memiavl.Options{
-		Dir:                 utils.GetCommitStorePath(scDir),
-		ZeroCopy:            config.ZeroCopy,
-		AsyncCommitBuffer:   config.AsyncCommitBuffer,
-		SnapshotInterval:    config.SnapshotInterval,
-		SnapshotKeepRecent:  config.SnapshotKeepRecent,
-		SnapshotWriterLimit: config.SnapshotWriterLimit,
-		CacheSize:           config.CacheSize,
-		CreateIfMissing:     true,
+		Dir:                              utils.GetCommitStorePath(scDir),
+		ZeroCopy:                         config.ZeroCopy,
+		AsyncCommitBuffer:                config.AsyncCommitBuffer,
+		SnapshotInterval:                 config.SnapshotInterval,
+		SnapshotKeepRecent:               config.SnapshotKeepRecent,
+		SnapshotWriterLimit:              config.SnapshotWriterLimit,
+		CacheSize:                        config.CacheSize,
+		CreateIfMissing:                  true,
+		OnlyAllowExportOnSnapshotVersion: config.OnlyAllowExportOnSnapshotVersion,
 	}
 	commitStore := &CommitStore{
 		logger: logger,

--- a/sc/store.go
+++ b/sc/store.go
@@ -128,7 +128,7 @@ func (cs *CommitStore) GetTreeByName(name string) types.Tree {
 }
 
 func (cs *CommitStore) Exporter(version int64) (types.Exporter, error) {
-	exporter, err := memiavl.NewMultiTreeExporter(cs.opts.Dir, uint32(version), true)
+	exporter, err := memiavl.NewMultiTreeExporter(cs.opts.Dir, uint32(version), cs.opts.OnlyAllowExportOnSnapshotVersion)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR added a new config to only allow state sync export creation to happen after we have a memiavl snapshot for that height