### PR TITLE
Fix nil pointer issue for corrupted log recovery

### DIFF
--- a/stream/changelog/changelog.go
+++ b/stream/changelog/changelog.go
@@ -231,6 +231,9 @@ func (stream *Stream) Close() error {
 
 // open opens the replay log, try to truncate the corrupted tail if there's any
 func open(dir string, opts *wal.Options) (*wal.Log, error) {
+	if opts == nil {
+		opts = wal.DefaultOptions
+	}
 	rlog, err := wal.Open(dir, opts)
 	if errors.Is(err, wal.ErrCorrupt) {
 		// try to truncate corrupted tail

--- a/stream/changelog/changelog_test.go
+++ b/stream/changelog/changelog_test.go
@@ -158,3 +158,25 @@ func TestAsyncWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), lastIndex)
 }
+
+func TestOpenWithNilOptions(t *testing.T) {
+	dir := t.TempDir()
+
+	// Test that open function handles nil options correctly
+	log, err := open(dir, nil)
+	require.NoError(t, err)
+	require.NotNil(t, log)
+
+	// Verify the log is functional by checking first and last index
+	firstIndex, err := log.FirstIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), firstIndex)
+
+	lastIndex, err := log.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), lastIndex)
+
+	// Clean up
+	err = log.Close()
+	require.NoError(t, err)
+}

--- a/stream/changelog/utils.go
+++ b/stream/changelog/utils.go
@@ -18,7 +18,10 @@ func LogPath(dir string) string {
 
 // GetLastIndex returns the last written index of the replay log
 func GetLastIndex(dir string) (index uint64, err error) {
-	rlog, err := open(dir, nil)
+	rlog, err := open(dir, &wal.Options{
+		NoSync: true,
+		NoCopy: true,
+	})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Describe your changes and provide context
This PR fix the nil pointer when logs are corrupted. Also added a unit test to capture it.

## Testing performed to validate your change
Added a unit test