### PR TITLE
[MemIAVL] Create snapshot whenever height diff exceed interval

### DIFF
--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -550,12 +550,12 @@ func (db *DB) rewriteIfApplicable(height int64) {
 		return
 	}
 
-	if height%int64(db.snapshotInterval) != 0 {
+	if db.snapshotInterval <= 0 || height <= 0 || height < db.MultiTree.SnapshotVersion() {
 		return
 	}
 
 	// create snapshot when current height - last snapshot height > interval
-	if db.snapshotInterval > 0 && height-db.MultiTree.SnapshotVersion() > int64(db.snapshotInterval) {
+	if height-db.MultiTree.SnapshotVersion() >= int64(db.snapshotInterval) {
 		if err := db.rewriteSnapshotBackground(); err != nil {
 			db.logger.Error("failed to rewrite snapshot in background", "err", err)
 		}

--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -546,12 +546,19 @@ func (db *DB) reloadMultiTree(mtree *MultiTree) error {
 
 // rewriteIfApplicable execute the snapshot rewrite strategy according to current height
 func (db *DB) rewriteIfApplicable(height int64) {
+	if db.snapshotRewriteChan != nil {
+		return
+	}
+
 	if height%int64(db.snapshotInterval) != 0 {
 		return
 	}
 
-	if err := db.rewriteSnapshotBackground(); err != nil {
-		db.logger.Error("failed to rewrite snapshot in background", "err", err)
+	// create snapshot when current height - last snapshot height > interval
+	if db.snapshotInterval > 0 && height-db.MultiTree.SnapshotVersion() > int64(db.snapshotInterval) {
+		if err := db.rewriteSnapshotBackground(); err != nil {
+			db.logger.Error("failed to rewrite snapshot in background", "err", err)
+		}
 	}
 }
 

--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -623,12 +623,14 @@ func (db *DB) rewriteSnapshotBackground() error {
 }
 
 func (db *DB) Close() error {
+	db.logger.Info("Closing memiavl db...")
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 	errs := []error{}
 	db.pruneSnapshotLock.Lock()
 	defer db.pruneSnapshotLock.Unlock()
 	// Close stream handler
+	db.logger.Info("Closing stream handler...")
 	if db.streamHandler != nil {
 		err := db.streamHandler.Close()
 		errs = append(errs, err)
@@ -636,6 +638,7 @@ func (db *DB) Close() error {
 	}
 
 	// Close rewrite channel
+	db.logger.Info("Closing rewrite channel...")
 	if db.snapshotRewriteChan != nil {
 		db.snapshotRewriteCancelFunc()
 		<-db.snapshotRewriteChan
@@ -646,12 +649,13 @@ func (db *DB) Close() error {
 	errs = append(errs, db.MultiTree.Close())
 
 	// Close file lock
+	db.logger.Info("Closing file lock...")
 	if db.fileLock != nil {
 		errs = append(errs, db.fileLock.Unlock())
 		errs = append(errs, db.fileLock.Destroy())
 		db.fileLock = nil
 	}
-
+	db.logger.Info("Closed memiavl db.")
 	return errorutils.Join(errs...)
 }
 

--- a/sc/memiavl/db_test.go
+++ b/sc/memiavl/db_test.go
@@ -137,6 +137,18 @@ func TestRewriteSnapshotBackground(t *testing.T) {
 	stopped = true
 }
 
+// helper to commit one change to bump height
+func RequireCommitWithNoError(t *testing.T, db *DB, key, val string) int64 {
+	pairs := []*iavl.KVPair{{Key: []byte(key), Value: []byte(val)}}
+	cs := []*proto.NamedChangeSet{
+		{Name: "test", Changeset: iavl.ChangeSet{pairs}},
+	}
+	require.NoError(t, db.ApplyChangeSets(cs))
+	v, err := db.Commit()
+	require.NoError(t, err)
+	return v
+}
+
 // Ensures snapshot rewrite is triggered when current height minus last snapshot height
 // exceeds the configured snapshot interval (strictly greater).
 func TestSnapshotTriggerOnIntervalDiff(t *testing.T) {
@@ -145,25 +157,14 @@ func TestSnapshotTriggerOnIntervalDiff(t *testing.T) {
 		Dir:                dir,
 		CreateIfMissing:    true,
 		InitialStores:      []string{"test"},
-		SnapshotInterval:   3,
+		SnapshotInterval:   5,
 		SnapshotKeepRecent: 0,
 	})
 	require.NoError(t, err)
 
-	// helper to commit one change to bump height
-	commitOnce := func(key, val string) int64 {
-		cs := []*proto.NamedChangeSet{
-			{Name: "test", Changeset: iavl.ChangeSet{Pairs: []*iavl.KVPair{{Key: []byte(key), Value: []byte(val)}}}},
-		}
-		require.NoError(t, db.ApplyChangeSets(cs))
-		v, err := db.Commit()
-		require.NoError(t, err)
-		return v
-	}
-
-	// Heights 1..5 should NOT trigger because (a) diff<=interval for <=3, and for 4,5 modulo!=0
-	for i := 1; i <= 5; i++ {
-		v := commitOnce("k"+strconv.Itoa(i), "v")
+	// Heights 1..4 should NOT trigger because diff<=interval
+	for i := 1; i < 5; i++ {
+		v := RequireCommitWithNoError(t, db, "k"+strconv.Itoa(i), "v")
 		require.Equal(t, int64(i), v)
 		// allow any background processing
 		time.Sleep(10 * time.Millisecond)
@@ -172,25 +173,21 @@ func TestSnapshotTriggerOnIntervalDiff(t *testing.T) {
 		require.Equal(t, int64(0), db.MultiTree.SnapshotVersion())
 	}
 
-	// Height 6: diff (6-0) > interval (3) and modulo==0 => should trigger rewrite
-	v := commitOnce("k6", "v")
-	require.Equal(t, int64(6), v)
+	// Height 5 should trigger rewrite
+	v := RequireCommitWithNoError(t, db, "k6", "v")
+	require.Equal(t, int64(5), v)
 
 	// wait briefly for background rewrite to start
-	deadline := time.Now().Add(2 * time.Second)
-	for db.snapshotRewriteChan == nil && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
-	}
-	require.NotNil(t, db.snapshotRewriteChan, "rewrite should have started at height 6")
-
-	// drive background completion
-	for db.snapshotRewriteChan != nil {
+	require.Eventually(t, func() bool {
+		return db.snapshotRewriteChan != nil
+	}, 3*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool {
 		require.NoError(t, db.checkAsyncTasks())
-		time.Sleep(5 * time.Millisecond)
-	}
+		return db.snapshotRewriteChan == nil
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// After completion, snapshot version should be 6
-	require.Equal(t, int64(6), db.MultiTree.SnapshotVersion())
+	require.Equal(t, int64(5), db.MultiTree.SnapshotVersion())
 
 	require.NoError(t, db.Close())
 }

--- a/sc/memiavl/db_test.go
+++ b/sc/memiavl/db_test.go
@@ -141,7 +141,7 @@ func TestRewriteSnapshotBackground(t *testing.T) {
 func RequireCommitWithNoError(t *testing.T, db *DB, key, val string) int64 {
 	pairs := []*iavl.KVPair{{Key: []byte(key), Value: []byte(val)}}
 	cs := []*proto.NamedChangeSet{
-		{Name: "test", Changeset: iavl.ChangeSet{pairs}},
+		{Name: "test", Changeset: iavl.ChangeSet{Pairs: pairs}},
 	}
 	require.NoError(t, db.ApplyChangeSets(cs))
 	v, err := db.Commit()

--- a/sc/memiavl/db_test.go
+++ b/sc/memiavl/db_test.go
@@ -165,12 +165,12 @@ func TestSnapshotTriggerOnIntervalDiff(t *testing.T) {
 	// Heights 1..4 should NOT trigger because diff<=interval
 	for i := 1; i < 5; i++ {
 		v := RequireCommitWithNoError(t, db, "k"+strconv.Itoa(i), "v")
-		require.Equal(t, int64(i), v)
+		require.EqualValues(t, i, v)
 		// allow any background processing
 		time.Sleep(10 * time.Millisecond)
 		require.Nil(t, db.snapshotRewriteChan, "rewrite should not start at height %d", i)
 		// snapshot version should remain 0 until rewrite
-		require.Equal(t, int64(0), db.MultiTree.SnapshotVersion())
+		require.EqualValues(t, 0, db.MultiTree.SnapshotVersion())
 	}
 
 	// Height 5 should trigger rewrite
@@ -187,7 +187,7 @@ func TestSnapshotTriggerOnIntervalDiff(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// After completion, snapshot version should be 6
-	require.Equal(t, int64(5), db.MultiTree.SnapshotVersion())
+	require.EqualValues(t, 5, db.MultiTree.SnapshotVersion())
 
 	require.NoError(t, db.Close())
 }

--- a/sc/memiavl/db_test.go
+++ b/sc/memiavl/db_test.go
@@ -137,6 +137,64 @@ func TestRewriteSnapshotBackground(t *testing.T) {
 	stopped = true
 }
 
+// Ensures snapshot rewrite is triggered when current height minus last snapshot height
+// exceeds the configured snapshot interval (strictly greater).
+func TestSnapshotTriggerOnIntervalDiff(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenDB(logger.NewNopLogger(), 0, Options{
+		Dir:                dir,
+		CreateIfMissing:    true,
+		InitialStores:      []string{"test"},
+		SnapshotInterval:   3,
+		SnapshotKeepRecent: 0,
+	})
+	require.NoError(t, err)
+
+	// helper to commit one change to bump height
+	commitOnce := func(key, val string) int64 {
+		cs := []*proto.NamedChangeSet{
+			{Name: "test", Changeset: iavl.ChangeSet{Pairs: []*iavl.KVPair{{Key: []byte(key), Value: []byte(val)}}}},
+		}
+		require.NoError(t, db.ApplyChangeSets(cs))
+		v, err := db.Commit()
+		require.NoError(t, err)
+		return v
+	}
+
+	// Heights 1..5 should NOT trigger because (a) diff<=interval for <=3, and for 4,5 modulo!=0
+	for i := 1; i <= 5; i++ {
+		v := commitOnce("k"+strconv.Itoa(i), "v")
+		require.Equal(t, int64(i), v)
+		// allow any background processing
+		time.Sleep(10 * time.Millisecond)
+		require.Nil(t, db.snapshotRewriteChan, "rewrite should not start at height %d", i)
+		// snapshot version should remain 0 until rewrite
+		require.Equal(t, int64(0), db.MultiTree.SnapshotVersion())
+	}
+
+	// Height 6: diff (6-0) > interval (3) and modulo==0 => should trigger rewrite
+	v := commitOnce("k6", "v")
+	require.Equal(t, int64(6), v)
+
+	// wait briefly for background rewrite to start
+	deadline := time.Now().Add(2 * time.Second)
+	for db.snapshotRewriteChan == nil && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.NotNil(t, db.snapshotRewriteChan, "rewrite should have started at height 6")
+
+	// drive background completion
+	for db.snapshotRewriteChan != nil {
+		require.NoError(t, db.checkAsyncTasks())
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// After completion, snapshot version should be 6
+	require.Equal(t, int64(6), db.MultiTree.SnapshotVersion())
+
+	require.NoError(t, db.Close())
+}
+
 func TestRlog(t *testing.T) {
 	dir := t.TempDir()
 	db, err := OpenDB(logger.NewNopLogger(), 0, Options{

--- a/sc/memiavl/snapshot_test.go
+++ b/sc/memiavl/snapshot_test.go
@@ -3,13 +3,8 @@ package memiavl
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"strconv"
 	"testing"
-	"time"
 
-	"github.com/alitto/pond"
 	errorutils "github.com/sei-protocol/sei-db/common/errors"
 	"github.com/sei-protocol/sei-db/common/logger"
 	"github.com/sei-protocol/sei-db/proto"
@@ -172,7 +167,6 @@ func TestDBSnapshotRestore(t *testing.T) {
 	require.Equal(t, len(ChangeSets), int(db.metadata.CommitInfo.Version))
 	testSnapshotRoundTrip(t, db)
 }
-
 
 func testSnapshotRoundTrip(t *testing.T, db *DB) {
 	exporter, err := NewMultiTreeExporter(db.dir, uint32(db.Version()), false)

--- a/sc/memiavl/snapshot_test.go
+++ b/sc/memiavl/snapshot_test.go
@@ -3,8 +3,13 @@ package memiavl
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/alitto/pond"
 	errorutils "github.com/sei-protocol/sei-db/common/errors"
 	"github.com/sei-protocol/sei-db/common/logger"
 	"github.com/sei-protocol/sei-db/proto"
@@ -167,6 +172,7 @@ func TestDBSnapshotRestore(t *testing.T) {
 	require.Equal(t, len(ChangeSets), int(db.metadata.CommitInfo.Version))
 	testSnapshotRoundTrip(t, db)
 }
+
 
 func testSnapshotRoundTrip(t *testing.T, db *DB) {
 	exporter, err := NewMultiTreeExporter(db.dir, uint32(db.Version()), false)


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
Currently, if snapshot interval is set to 10k, and previous snapshot is created at height 10000, when node got restart at height 20001, it will not start the next snapshot creation until height 30000. This will actually lead to higher snapshot gaps which will then lead to higher restart time.

Instead of using fixed window interval, we actually switched to a new snapshot policy where the next snapshot creation will happen immediately at current height after commit as long as the current height - last snapshot height >= snapshot interval.

## Testing performed to validate your change
Added unit test + Tested on RPC node

