### PR TITLE
MemIAVL should only only keep 1 snapshot

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,8 @@ package config
 
 const (
 	DefaultSnapshotInterval    = 10000
-	DefaultSnapshotKeepRecent  = 1
-	DefaultSnapshotWriterLimit = 1
+	DefaultSnapshotKeepRecent  = 0 //set to 0 to only keep one current snapshot
+	DefaultSnapshotWriterLimit = 8 //set to 8 to allow 8 concurrent snapshot writers
 	DefaultAsyncCommitBuffer   = 100
 	DefaultCacheSize           = 100000
 	DefaultSSKeepRecent        = 100000

--- a/config/config.go
+++ b/config/config.go
@@ -1,16 +1,15 @@
 package config
 
 const (
-	DefaultSnapshotInterval    = 10000
-	DefaultSnapshotKeepRecent  = 0 // set to 0 to only keep one current snapshot
-	DefaultSnapshotWriterLimit = 8 // set to 8 to allow 8 concurrent snapshot writers
-	DefaultAsyncCommitBuffer   = 100
-	DefaultCacheSize           = 100000
-	DefaultSSKeepRecent        = 100000
-	DefaultSSPruneInterval     = 600
-	DefaultSSImportWorkers     = 1
-	DefaultSSAsyncBuffer       = 100
-	DefaultSSHashRange         = 1000000
+	DefaultSnapshotInterval   = 10000
+	DefaultSnapshotKeepRecent = 0 // set to 0 to only keep one current snapshot
+	DefaultAsyncCommitBuffer  = 100
+	DefaultCacheSize          = 100000
+	DefaultSSKeepRecent       = 100000
+	DefaultSSPruneInterval    = 600
+	DefaultSSImportWorkers    = 1
+	DefaultSSAsyncBuffer      = 100
+	DefaultSSHashRange        = 1000000
 )
 
 type StateCommitConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,8 @@ package config
 
 const (
 	DefaultSnapshotInterval    = 10000
-	DefaultSnapshotKeepRecent  = 0 //set to 0 to only keep one current snapshot
-	DefaultSnapshotWriterLimit = 8 //set to 8 to allow 8 concurrent snapshot writers
+	DefaultSnapshotKeepRecent  = 0 // set to 0 to only keep one current snapshot
+	DefaultSnapshotWriterLimit = 8 // set to 8 to allow 8 concurrent snapshot writers
 	DefaultAsyncCommitBuffer   = 100
 	DefaultCacheSize           = 100000
 	DefaultSSKeepRecent        = 100000

--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -209,9 +209,7 @@ func OpenDB(logger logger.Logger, targetVersion int64, opts Options) (*DB, error
 			return nil, errorutils.Join(err, db.Close())
 		}
 	}
-	if db.streamHandler == nil {
-		fmt.Println("[Debug] DB steam handler is nil??")
-	}
+
 	// We need to prune snapshots during start up to avoid snapshot leaks
 	if !db.readOnly {
 		db.pruneSnapshots()
@@ -621,7 +619,8 @@ func (db *DB) Close() error {
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 	errs := []error{}
-
+	db.pruneSnapshotLock.Lock()
+	defer db.pruneSnapshotLock.Unlock()
 	// Close stream handler
 	if db.streamHandler != nil {
 		err := db.streamHandler.Close()

--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -212,6 +212,10 @@ func OpenDB(logger logger.Logger, targetVersion int64, opts Options) (*DB, error
 	if db.streamHandler == nil {
 		fmt.Println("[Debug] DB steam handler is nil??")
 	}
+	// We need to prune snapshots during start up to avoid snapshot leaks
+	if !db.readOnly {
+		db.pruneSnapshots()
+	}
 	return db, nil
 }
 

--- a/sc/memiavl/db.go
+++ b/sc/memiavl/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,7 +18,6 @@ import (
 	errorutils "github.com/sei-protocol/sei-db/common/errors"
 	"github.com/sei-protocol/sei-db/common/logger"
 	"github.com/sei-protocol/sei-db/common/utils"
-	"github.com/sei-protocol/sei-db/config"
 	"github.com/sei-protocol/sei-db/proto"
 	"github.com/sei-protocol/sei-db/stream/changelog"
 	"github.com/sei-protocol/sei-db/stream/types"
@@ -804,7 +804,8 @@ func initEmptyDB(dir string, initialVersion uint32) error {
 	tmp := NewEmptyMultiTree(initialVersion, 0)
 	snapshotDir := snapshotName(0)
 	// create tmp worker pool
-	pool := pond.New(config.DefaultSnapshotWriterLimit, config.DefaultSnapshotWriterLimit*10)
+	concurrency := runtime.NumCPU()
+	pool := pond.New(concurrency, concurrency*10)
 	defer pool.Stop()
 
 	if err := tmp.WriteSnapshot(context.Background(), filepath.Join(dir, snapshotDir), pool); err != nil {

--- a/sc/memiavl/export.go
+++ b/sc/memiavl/export.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime"
 
 	errorutils "github.com/sei-protocol/sei-db/common/errors"
 	"github.com/sei-protocol/sei-db/common/logger"
-	"github.com/sei-protocol/sei-db/config"
 	"github.com/sei-protocol/sei-db/sc/types"
 )
 
@@ -36,7 +36,7 @@ func NewMultiTreeExporter(dir string, version uint32, onlyAllowExportOnSnapshotV
 			Dir:                 dir,
 			ZeroCopy:            true,
 			ReadOnly:            true,
-			SnapshotWriterLimit: config.DefaultSnapshotWriterLimit,
+			SnapshotWriterLimit: runtime.NumCPU(),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("invalid height: %d, %w", version, err)

--- a/sc/memiavl/opts.go
+++ b/sc/memiavl/opts.go
@@ -61,4 +61,6 @@ func (opts *Options) FillDefaults() {
 	if opts.CacheSize < 0 {
 		opts.CacheSize = config.DefaultCacheSize
 	}
+
+	opts.SnapshotKeepRecent = config.DefaultSnapshotKeepRecent
 }

--- a/sc/memiavl/opts.go
+++ b/sc/memiavl/opts.go
@@ -2,6 +2,7 @@ package memiavl
 
 import (
 	"errors"
+	"runtime"
 
 	"github.com/sei-protocol/sei-db/config"
 )
@@ -55,7 +56,7 @@ func (opts *Options) FillDefaults() {
 	}
 
 	if opts.SnapshotWriterLimit <= 0 {
-		opts.SnapshotWriterLimit = config.DefaultSnapshotWriterLimit
+		opts.SnapshotWriterLimit = runtime.NumCPU()
 	}
 
 	if opts.CacheSize < 0 {


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
Currently MemIAVL allow user to configure keepRecent and set that to any arbitrary value to keep more than one snapshot history, however, the issue is that keeping more snapshots will lead to unnecessary hold onto the page cache, and thus not releasing page cache in time.

Fix:
This PR forces to overwrite keepRecent to 0 so that we only keep one current snapshot, and 0 historical snapshots to minimize the page cache usage. The longer term plan is to deprecate this config from the user-facing perspective so that user shouldn't need to set that config any more


THIS PR also fix another bug where snapshot pruning is not working due to restart at the wrong time. Currently pruning snapshot only happens after a snapshot is successfully created and switched. However if restart happens during this time, it could lead to pruning not being triggered properly after snapshot is created, and thus lead to snapshot leakage

## Testing performed to validate your change

