### PR TITLE
Revert "Merge pull request #105 from sei-protocol/PebbleSurfaceErrors"

### DIFF
--- a/ss/sqlite/db.go
+++ b/ss/sqlite/db.go
@@ -148,7 +148,7 @@ func (db *Database) SetEarliestVersion(version int64, ignoreVersion bool) error 
 
 func (db *Database) Has(storeKey string, version int64, key []byte) (bool, error) {
 	val, err := db.Get(storeKey, version, key)
-	if err != nil && !errors.Is(err, errorutils.ErrRecordNotFound) {
+	if err != nil {
 		return false, err
 	}
 
@@ -172,6 +172,10 @@ func (db *Database) Get(storeKey string, targetVersion int64, key []byte) ([]byt
 		tomb  int64
 	)
 	if err := stmt.QueryRow(storeKey, key, targetVersion).Scan(&value, &tomb); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+
 		return nil, fmt.Errorf("failed to query row: %w", err)
 	}
 

--- a/ss/test/storage_test_suite.go
+++ b/ss/test/storage_test_suite.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/cosmos/iavl"
-	errorutils "github.com/sei-protocol/sei-db/common/errors"
 	"github.com/sei-protocol/sei-db/config"
 	"github.com/sei-protocol/sei-db/ss/types"
 	"github.com/stretchr/testify/suite"
@@ -142,7 +141,7 @@ func (s *StorageTestSuite) TestDatabaseGetVersionedKey() {
 	// all queries after version 15 should return nil
 	for i := int64(15); i <= 17; i++ {
 		bz, err = db.Get(storeKey1, i, key)
-		s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
+		s.Require().NoError(err)
 		s.Require().Nil(bz)
 
 		ok, err = db.Has(storeKey1, i, key)
@@ -619,11 +618,10 @@ func (s *StorageTestSuite) TestDatabasePrune() {
 			val := fmt.Sprintf("val%03d-%03d", i, v)
 
 			bz, err := db.Get(storeKey1, v, []byte(key))
+			s.Require().NoError(err)
 			if v <= 25 {
-				s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
 				s.Require().Nil(bz)
 			} else {
-				s.Require().NoError(err)
 				s.Require().Equal([]byte(val), bz)
 			}
 		}
@@ -646,7 +644,7 @@ func (s *StorageTestSuite) TestDatabasePrune() {
 			key := fmt.Sprintf("key%03d", i)
 
 			bz, err := db.Get(storeKey1, v, []byte(key))
-			s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
+			s.Require().NoError(err)
 			s.Require().Nil(bz)
 		}
 	}
@@ -690,7 +688,7 @@ func (s *StorageTestSuite) TestDatabasePruneKeepRecent() {
 
 	// ensure queries for versions 50 and older return nil
 	bz, err := db.Get(storeKey1, 49, key)
-	s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
+	s.Require().Nil(err)
 	s.Require().Nil(bz)
 
 	itr, err := db.Iterator(storeKey1, 49, nil, nil)
@@ -738,11 +736,11 @@ func (s *StorageTestSuite) TestDatabasePruneKeepLastVersion() {
 
 		// Verify that all keys before prune height are deleted
 		bz, err := db.Get(storeKey1, 100, []byte("key000"))
-		s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
+		s.Require().NoError(err)
 		s.Require().Nil(bz)
 
 		bz, err = db.Get(storeKey1, 160, []byte("key001"))
-		s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
+		s.Require().NoError(err)
 		s.Require().Nil(bz)
 
 		// Verify keys after prune height can be retrieved
@@ -932,7 +930,7 @@ func (s *StorageTestSuite) TestParallelWriteAndPruning() {
 	// check if the data is pruned
 	version := int64(latestVersion - prunePeriod)
 	val, err := db.Get(storeKey1, version, []byte(fmt.Sprintf("key-%d-%03d", version-1, 0)))
-	s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
+	s.Require().Nil(err)
 	s.Require().Nil(val)
 
 	version = int64(latestVersion)
@@ -1142,11 +1140,10 @@ func (s *StorageTestSuite) TestParallelIterationAndPruning() {
 			val := fmt.Sprintf("val%03d-%03d", i, v)
 
 			bz, err := db.Get(storeKey1, v, []byte(key))
+			s.Require().NoError(err)
 			if v <= int64(latestVersion-numHeightsPruned) {
-				s.Require().ErrorIs(err, errorutils.ErrRecordNotFound)
 				s.Require().Nil(bz)
 			} else {
-				s.Require().NoError(err)
 				s.Require().Equal([]byte(val), bz)
 			}
 		}


### PR DESCRIPTION
This reverts commit de1d7fe668bbf298de75f38384dd17e4e686f96d, reversing changes made to 253395395af8c33a3aeb86cf180ef92c4728e02e.

## Describe your changes and provide context
- Revert surfacing errors from db layer since the rpc / keeper / store layer hard codes a lot of handling of record not found and there needs to be a larger refactor
- Can re introduce this error after a redesign and consideration of impact

## Testing performed to validate your change
- Verified in unit tests and on node
