### PR TITLE
Fix async flush logic and flaky unit test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,9 +62,6 @@ type StateStoreConfig struct {
 	// default to empty
 	DBDirectory string `mapstructure:"db-directory"`
 
-	// DedicatedChangelog defines if we should use a separate changelog for SS store other than sharing with SC
-	DedicatedChangelog bool `mapstructure:"dedicated-changelog"`
-
 	// Backend defines the backend database used for state-store
 	// Supported backends: pebbledb, rocksdb
 	// defaults to pebbledb
@@ -101,7 +98,6 @@ func DefaultStateCommitConfig() StateCommitConfig {
 	return StateCommitConfig{
 		Enable:             true,
 		AsyncCommitBuffer:  DefaultAsyncCommitBuffer,
-		CacheSize:          DefaultCacheSize,
 		SnapshotInterval:   DefaultSnapshotInterval,
 		SnapshotKeepRecent: DefaultSnapshotKeepRecent,
 	}

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -152,34 +152,35 @@ func New(dataDir string, config config.StateStoreConfig) (*Database, error) {
 	}
 	database.lastRangeHashedCache = lastHashed
 
-	if config.DedicatedChangelog {
-		if config.KeepRecent < 0 {
-			return nil, errors.New("KeepRecent must be non-negative")
-		}
-		streamHandler, _ := changelog.NewStream(
-			logger.NewNopLogger(),
-			utils.GetChangelogPath(dataDir),
-			changelog.Config{
-				DisableFsync:  true,
-				ZeroCopy:      true,
-				KeepRecent:    uint64(config.KeepRecent),
-				PruneInterval: 300 * time.Second,
-			},
-		)
-		database.streamHandler = streamHandler
-		go database.writeAsyncInBackground()
+	if config.KeepRecent < 0 {
+		return nil, errors.New("KeepRecent must be non-negative")
 	}
+	streamHandler, _ := changelog.NewStream(
+		logger.NewNopLogger(),
+		utils.GetChangelogPath(dataDir),
+		changelog.Config{
+			DisableFsync:  true,
+			ZeroCopy:      true,
+			KeepRecent:    uint64(config.KeepRecent),
+			PruneInterval: time.Duration(config.PruneIntervalSeconds) * time.Second,
+		},
+	)
+	database.streamHandler = streamHandler
+	go database.writeAsyncInBackground()
+
 	return database, nil
 }
 
 func (db *Database) Close() error {
+	// First, stop accepting new pending changes and drain the worker
+	close(db.pendingChanges)
+	// Wait for the async writes to finish
+	db.asyncWriteWG.Wait()
+	// Now close the WAL stream
 	if db.streamHandler != nil {
 		_ = db.streamHandler.Close()
 		db.streamHandler = nil
-		close(db.pendingChanges)
 	}
-	// Wait for the async writes to finish
-	db.asyncWriteWG.Wait()
 	err := db.storage.Close()
 	db.storage = nil
 	return err

--- a/ss/pebbledb/db.go
+++ b/ss/pebbledb/db.go
@@ -172,12 +172,12 @@ func New(dataDir string, config config.StateStoreConfig) (*Database, error) {
 }
 
 func (db *Database) Close() error {
-	// First, stop accepting new pending changes and drain the worker
-	close(db.pendingChanges)
-	// Wait for the async writes to finish
-	db.asyncWriteWG.Wait()
-	// Now close the WAL stream
 	if db.streamHandler != nil {
+		// First, stop accepting new pending changes and drain the worker
+		close(db.pendingChanges)
+		// Wait for the async writes to finish
+		db.asyncWriteWG.Wait()
+		// Now close the WAL stream
 		_ = db.streamHandler.Close()
 		db.streamHandler = nil
 	}

--- a/ss/pebbledb/hash_test.go
+++ b/ss/pebbledb/hash_test.go
@@ -339,7 +339,7 @@ func TestAsyncComputeMissingRanges(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait a bit for the async computation to complete
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// We should now have hashed up to version 30 (3 complete ranges)
 	lastHashed, err := db.GetLastRangeHashed()

--- a/ss/pebbledb/hash_test.go
+++ b/ss/pebbledb/hash_test.go
@@ -22,12 +22,11 @@ func setupTestDB(t *testing.T) (*Database, string) {
 
 	// Set up config with hash range enabled
 	cfg := config.StateStoreConfig{
-		HashRange:          10, // 10 blocks per hash range
-		AsyncWriteBuffer:   100,
-		KeepRecent:         100,
-		KeepLastVersion:    true,
-		ImportNumWorkers:   4,
-		DedicatedChangelog: false,
+		HashRange:        10, // 10 blocks per hash range
+		AsyncWriteBuffer: 100,
+		KeepRecent:       100,
+		KeepLastVersion:  true,
+		ImportNumWorkers: 4,
 	}
 
 	db, err := New(tempDir, cfg)

--- a/ss/rocksdb/db.go
+++ b/ss/rocksdb/db.go
@@ -110,20 +110,18 @@ func New(dataDir string, config config.StateStoreConfig) (*Database, error) {
 		pendingChanges:  make(chan VersionedChangesets, config.AsyncWriteBuffer),
 	}
 
-	if config.DedicatedChangelog {
-		streamHandler, _ := changelog.NewStream(
-			logger.NewNopLogger(),
-			utils.GetChangelogPath(dataDir),
-			changelog.Config{
-				DisableFsync:  true,
-				ZeroCopy:      true,
-				KeepRecent:    uint64(config.KeepRecent),
-				PruneInterval: 300 * time.Second,
-			},
-		)
-		database.streamHandler = streamHandler
-		go database.writeAsyncInBackground()
-	}
+	streamHandler, _ := changelog.NewStream(
+		logger.NewNopLogger(),
+		utils.GetChangelogPath(dataDir),
+		changelog.Config{
+			DisableFsync:  true,
+			ZeroCopy:      true,
+			KeepRecent:    uint64(config.KeepRecent),
+			PruneInterval: time.Duration(config.PruneIntervalSeconds) * time.Second,
+		},
+	)
+	database.streamHandler = streamHandler
+	go database.writeAsyncInBackground()
 
 	return database, nil
 }
@@ -494,17 +492,16 @@ func (db *Database) WriteBlockRangeHash(storeKey string, beginBlockRange, endBlo
 }
 
 func (db *Database) Close() error {
+	// Close the pending changes channel to signal the background goroutine to stop
+	close(db.pendingChanges)
+	// Wait for the async writes to finish processing all buffered items
+	db.asyncWriteWG.Wait()
 	if db.streamHandler != nil {
 		// Close the changelog stream first
 		db.streamHandler.Close()
-		// Close the pending changes channel to signal the background goroutine to stop
-		close(db.pendingChanges)
-		// Wait for the async writes to finish processing all buffered items
-		db.asyncWriteWG.Wait()
 		// Only set to nil after background goroutine has finished
 		db.streamHandler = nil
 	}
-
 	db.storage.Close()
 	db.storage = nil
 	db.cfHandle = nil

--- a/ss/rocksdb/db.go
+++ b/ss/rocksdb/db.go
@@ -492,13 +492,13 @@ func (db *Database) WriteBlockRangeHash(storeKey string, beginBlockRange, endBlo
 }
 
 func (db *Database) Close() error {
-	// Close the pending changes channel to signal the background goroutine to stop
-	close(db.pendingChanges)
-	// Wait for the async writes to finish processing all buffered items
-	db.asyncWriteWG.Wait()
 	if db.streamHandler != nil {
+		// Close the pending changes channel to signal the background goroutine to stop
+		close(db.pendingChanges)
+		// Wait for the async writes to finish processing all buffered items
+		db.asyncWriteWG.Wait()
 		// Close the changelog stream first
-		db.streamHandler.Close()
+		_ = db.streamHandler.Close()
 		// Only set to nil after background goroutine has finished
 		db.streamHandler = nil
 	}

--- a/ss/store_test.go
+++ b/ss/store_test.go
@@ -15,16 +15,15 @@ import (
 
 func TestNewStateStore(t *testing.T) {
 	tempDir := os.TempDir()
-	homeDir := filepath.Join(tempDir, "seidb")
+	homeDir := filepath.Join(tempDir, "pebbledb")
 	ssConfig := config.StateStoreConfig{
-		DedicatedChangelog: true,
-		Backend:            string(PebbleDBBackend),
-		AsyncWriteBuffer:   50,
-		KeepRecent:         500,
+		Backend:          string(PebbleDBBackend),
+		AsyncWriteBuffer: 100,
+		KeepRecent:       500,
 	}
 	stateStore, err := NewStateStore(logger.NewNopLogger(), homeDir, ssConfig)
 	require.NoError(t, err)
-	for i := 1; i < 20; i++ {
+	for i := 1; i < 50; i++ {
 		var changesets []*proto.NamedChangeSet
 		kvPair := &iavl.KVPair{
 			Delete: false,
@@ -51,7 +50,7 @@ func TestNewStateStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure key and values can be found
-	for i := 1; i < 20; i++ {
+	for i := 1; i < 50; i++ {
 		value, err := stateStore.Get("storeA", int64(i), []byte(fmt.Sprintf("key%d", i)))
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("value%d", i), string(value))


### PR DESCRIPTION
## Describe your changes and provide context
This PR will fix 3 issues:
1. Flaky unit test is caused by async writes not committing latest version in time before db is closed, resulting in the recovery process being skipped since latestVersion = 0
2. Async write is only enabled properly when useDedicatedChangelog=true, however, we want all async writes are going through the extra WAL file to avoid data loss so that we can recover during initilization.
3. Fix closing order, we should close the channel first, wait for all pending changes to be flushed to DB and then closing the WAL
## Testing performed to validate your change

